### PR TITLE
Added Western Sydney International (WSI) Airport

### DIFF
--- a/airports.csv
+++ b/airports.csv
@@ -8977,6 +8977,7 @@ WSD,KWSD,Condron AAF,32.38333,-106.48333,4291,,America/Denver,WSD,US,White Sands
 WSF,,Sarichef,54.5861889,-164.902081,236,,America/Anchorage,WSF,US,Akutan,Alaska,Aleutians East Borough,AP
 WSG,KAFJ,County,40.166668,-80.25,1040,,America/New_York,WSG,US,Washington,Pennsylvania,Washington County,AP
 WSH,KHWV,Brookhaven,40.75,-72.833336,0,,America/New_York,WSH,US,Mastic Beach,New York,Suffolk County,AP
+WSI,YSWS,Western Sydney International (Nancy Bird Walton) Airport,-33.88806,150.71472,262,,Australia/Sydney,WSI,AU,Sydney,New South Wales,,AP
 WSJ,,San Juan SPB,57.73111,-153.31833,42,,America/Anchorage,WSJ,US,Kodiak Station,Alaska,Kodiak Island Borough,AP
 WSK,ZUWS,Chongqing Wushan Airport,31.07157155,109.71336937776792,5800,,Asia/Shanghai,WSK,CN,Quchi,Chongqing Shi,,AP
 WSM,WSM,Wiseman,67.4059294,-150.1190072,1286,,America/Anchorage,WSM,US,Nuiqsut,Alaska,North Slope Borough,AP


### PR DESCRIPTION
Scheduled to open October 2026. But are currently accepting bookings for flights after Oct