### PR TITLE
feat: add Noida International Airport (DXN, VIND)

### DIFF
--- a/airports.csv
+++ b/airports.csv
@@ -2022,6 +2022,7 @@ DXB,OMDB,Dubai Airport,25.248665,55.352917,39,http://www.dubaiairport.com/dia/en
 DXD,YDIX,Dixie,-15.166667,143.66667,574,,Australia/Brisbane,DXD,AU,,,,AP
 DXE,KMBO,Bruce Campbell Field,32.4392835,-90.10313414239927,246,http://www.madisonthecity.com/airport,America/Chicago,DXE,US,Madison,Mississippi,Madison County,AP
 DXJ,ZGXX,Xiangxi Biancheng Airport,28.4972,109.5218,2299,,Asia/Shanghai,DXJ,CN,,,Hunan,AP
+DXN,VIND,Noida International Airport,28.179868,77.611843,644,https://www.niairport.in,Asia/Kolkata,DXN,IN,Jewar,Uttar Pradesh,Gautam Buddha Nagar,AP
 DXR,KDXR,Danbury Municipal Airport,41.3721531,-73.48139626519684,433,,America/New_York,DXR,US,Danbury,Connecticut,Fairfield County,AP
 DYA,YDYS,Dysart,-23.5,148.0,672,,Australia/Brisbane,DYA,AU,,,,AP
 DYG,ZGDY,Zhangjiajie Hehua Airport,29.103868499999997,110.44472066563625,679,,Asia/Shanghai,DYG,CN,,,,AP


### PR DESCRIPTION
Adds Noida International Airport to `airports.csv`.

- **IATA:** DXN
- **ICAO:** VIND
- **City:** Noida (Jewar), Gautam Buddh Nagar, Uttar Pradesh, India

Single-row addition, inserted in sorted order with CRLF line endings preserved.