### PR TITLE
feat: add Purnea Airport (PXN, VEPU)

### DIFF
--- a/airports.csv
+++ b/airports.csv
@@ -6405,6 +6405,7 @@ PXA,WIPY,Atung Bungsu Airport,-4.0225,103.379167,2020,,Asia/Jakarta,PXA,ID,Kotaa
 PXH,YPMH,Prominent Hill,-29.7101355,135.52772941953702,692,,Australia/Adelaide,PXH,AU,,,,AP
 PXL,P10,Polacca,35.8,-110.333336,5823,,America/Phoenix,PXL,US,First Mesa,Arizona,Navajo County,AP
 PXM,MMPS,Puerto Escondido Airport,15.85,-97.083336,0,,America/Mexico_City,PXM,MX,Puerto Escondido,Oaxaca,San Pedro Mixtepec -Dto. 22 -,AP
+PXN,VEPU,Purnea Airport,25.759599685668945,87.41000366210938,129,,Asia/Kolkata,PXN,IN,Purnia,Bihar,Purnia,AP
 PXO,LPPS,Porto Santo Airport,33.07362365,-16.34816497905559,252,http://www.anam.pt/Porto-Santo-411.aspx,Atlantic/Madeira,PXO,PT,Vila de Porto Santo,Madeira,Porto Santo,AP
 PXR,VTUJ,Surin,14.86680565,103.4979606001036,331,,Asia/Bangkok,PXR,TH,Surin,Surin,,AP
 PXU,VVPK,Pleiku Airport,14.004424,108.0135475589313,2411,,Asia/Ho_Chi_Minh,PXU,VN,Pleiku,Gia Lai,,AP


### PR DESCRIPTION
Adds Purnea Airport to `airports.csv`.

- **IATA:** PXN
- **ICAO:** VEPU
- **City:** Purnia, Bihar, India
- **Coordinates / elevation:** 25.7596, 87.41000366, 129 ft

Codes and location cross-checked against OurAirports. Opened to public passenger service in September 2025. Single-row addition, inserted in sorted order with CRLF line endings preserved.