### PR TITLE
fix: update incorrect airport details

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,15 @@ If you like this project, give it a star on GitHub, and consider supporting its 
 
 [![ko-fi](https://www.ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/lxndrblz/)
 
+If you use this dataset in a commercial context, please consider supporting the project with a donation via Ko-fi:
+
+https://ko-fi.com/lxndrblz/
+
+Or consider using the hosted API service:
+
+https://rapidapi.com/travel-tools-travel-tools-default/api/iata-airports/
+
+## Data License
+
+All data in this repository is licensed under [Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/).
+

--- a/airports.csv
+++ b/airports.csv
@@ -2961,7 +2961,6 @@ GVN,UHKM,May-Gatka,48.9249059,140.0297395,790,,Asia/Vladivostok,GVN,RU,Mayskiy,K
 GVP,YGNV,Greenvale,-15.783333,144.61667,551,,Australia/Brisbane,GVP,AU,,,,AP
 GVR,SBGV,Governador Valadares Airport,-18.850279,-41.933334,492,,America/Sao_Paulo,GVR,BR,Governador Valadares,Minas Gerais,Governador Valadares,AP
 GVT,KGVT,Majors Field,33.066666,-96.06167,564,,America/Chicago,GVT,US,Greenville,Texas,Hunt County,AP
-GVW,,Richards-Gebaur,38.88333,-94.53333,1053,,America/Chicago,GVW,US,Grandview,Missouri,Jackson County,AP
 GVX,ESSK,Sandviken,60.592861799999994,16.95115381638249,49,,Europe/Stockholm,GVX,SE,Valbo,Gaevleborg,Gavle Kommun,AP
 GWA,VYGW,Gwa,21.0,94.0,3959,,Asia/Rangoon,GWA,MM,,,,AP
 GWD,OPGD,Gwadar Airport,25.2323386,62.32852684802599,26,,Asia/Karachi,GWD,PK,Gwadar,Balochistan,,AP
@@ -3000,7 +2999,6 @@ GYZ,YGRM,Gruyere Mine Airport,-28.0339912,123.8140464,1502,,Australia/Perth,GYZ,
 GZA,LVGZ,Gaza - Yaser Arafat International Airport,31.24639,34.27611,288,,Asia/Gaza,GZA,PS,Shukat as Sufi,Gaza Strip,,AP
 GZG,ZUGZ,Garze Gesar Airport,31.7548325,99.553507,13484,,Asia/Shanghai,GZG,CN,Ganzi,Sichuan,,AP
 GZI,OAGN,Ghazni,33.0,68.416664,7654,,Asia/Kabul,GZI,AF,Khayr Kot,Paktika,,AP
-GZM,,Gozo Heliport,36.041668,14.208333,347,,Europe/Malta,GZM,MT,Saint Lucia,Saint Lucia,,AP
 GZO,AGGN,Gizo Airport,-8.0999822,156.86506062321428,62,,Pacific/Guadalcanal,GZO,SB,,,,AP
 GZP,LTFG,Gazipasa Airport,36.29880585,32.29718214713545,59,,Europe/Istanbul,GZP,TR,Gazipasa,Antalya,,AP
 GZT,LTAJ,Gaziantep Airport,36.9479318,37.47319308119735,2250,,Europe/Istanbul,GZT,TR,Oguzeli,Gaziantep,,AP
@@ -3009,7 +3007,6 @@ HAA,ENHK,Hasvik Airport,70.46667,22.15,0,https://avinor.no/en/airport/hasvik-air
 HAB,KHAB,Marion County,34.15,-88.1,541,,America/Chicago,HAB,US,Hamilton,Alabama,Marion County,AP
 HAC,RJTH,Hachijo Jima Airport,33.117947,139.78122,387,,Asia/Tokyo,HAC,JP,,,,AP
 HAD,ESMT,Halmstad Airport,56.69265085000001,12.820655511825056,32,,Europe/Stockholm,HAD,SE,Halmstad,Halland,Halmstads Kommun,AP
-HAE,,Havasupai,36.230556,-112.66944,4366,,America/Phoenix,HAE,US,,,,AP
 HAF,KHAF,Half Moon,37.466667,-122.433334,59,,America/Los_Angeles,HAF,US,Half Moon Bay,California,San Mateo County,AP
 HAH,FMCH,Prince Said Ibrahim Internatonal Airport,-11.537275,43.27492,104,,Indian/Comoro,YVA,KM,,,,AP
 HAI,KHAI,Dr Haines,41.95,-85.63333,856,,America/Detroit,HAI,US,Three Rivers,Michigan,Saint Joseph County,AP
@@ -3019,7 +3016,6 @@ HAL,FYHI,Halali,-19.966667,13.066667,400,,Africa/Windhoek,HAL,NA,,,,AP
 HAM,EDDH,Hamburg Airport,53.63636215,9.994550134684175,36,https://www.hamburg-airport.de/en/,Europe/Berlin,HAM,DE,Fuhlsbuettel,Hamburg,,AP
 HAN,VVNB,Noi Bai International Airport,21.2190339,105.8044969796485,32,,Asia/Ho_Chi_Minh,HAN,VN,Soc Son,Ha Noi,,AP
 HAO,KHAO,Hamilton,39.4,-84.566666,570,http://bcra.butlercountyohio.org/,America/New_York,HAO,US,Hamilton,Ohio,Butler County,AP
-HAP,,Long Island,-20.5,148.75,0,,Australia/Brisbane,HAP,AU,,,,AP
 HAQ,VRMH,Hanimaadhoo Airport,6.74674065,73.16926271391242,22,,Indian/Maldives,HAQ,MV,Dhidhdhoo,Upper North,,AP
 HAR,KCXY,Capital City,40.21611,-76.85222,334,http://www.flycxy.com/,America/New_York,HAR,US,Steelton,Pennsylvania,Dauphin County,AP
 HAS,OEHL,Hail Airport,27.4397262,41.6856697,3159,,Asia/Riyadh,HAS,SA,Hayil,Mintaqat Ha'il,,AP
@@ -3027,27 +3023,21 @@ HAT,YHTL,Heathlands,-19.720833,140.58333,367,,Australia/Brisbane,HAT,AU,,,,AP
 HAU,ENHD,Haugesund Airport,59.34292,5.2152365479364455,88,https://avinor.no/en/airport/haugesund-airport/,Europe/Oslo,HAU,NO,Vedavagen,Rogaland,Karmoy,AP
 HAV,MUHA,Jose Marti International Airport,22.987384849999998,-82.41424753295806,288,,America/Havana,HAV,CU,Boyeros,La Habana,,AP
 HAW,EGFE,Haverfordwest,51.8331205,-4.9610359,154,,Europe/London,HAW,GB,Haverfordwest,Wales,Pembrokeshire,AP
-HAX,,Hatbox Field,35.75,-95.416664,646,,America/Chicago,MKO,US,,,,AP
 HAY,HAY,Haycock,65.2008333,-161.1566667,150,,America/Anchorage,HAY,US,,,,AP
 HAZ,,Hatzfeldthaven,-4.433333,145.18333,921,,Pacific/Port_Moresby,HAZ,PG,,,,AP
 HBA,YMHB,Hobart International Airport,-42.837257,147.50519,26,,Australia/Hobart,HBA,AU,Seven Mile Beach,Tasmania,Clarence,AP
 HBB,NM83,Industrial Airpark,32.7,-103.13333,3608,,America/Denver,HOB,US,,,,AP
-HBC,,Hanus Bay,57.5,-135.91667,0,,America/Sitka,HBC,US,,,,AP
 HBD,AYHB,Habi,-6.32042775,142.48902706934854,935,,Pacific/Port_Moresby,HBD,PG,,,,AP
 HBE,HEBA,Borg El Arab Airport,30.922234,29.686504,167,,Africa/Cairo,ALY,EG,Alexandria,Alexandria,,AP
 HBG,KHBG,The Hattiesburg-Bobby L. Chain Mun.,31.316668,-89.26667,124,,America/Chicago,HBG,US,Hattiesburg,Mississippi,Forrest County,AP
 HBH,,Hobart Bay,57.408333,-133.46666,0,,America/Juneau,HBH,US,,,,AP
-HBI,,Harbour Island,25.516666,-76.6,0,,America/Nassau,HBI,BS,Dunmore Town,Harbour Island,,AP
 HBK,P14,Holbrook Municipal,34.941733150000005,-110.14722023079597,5236,,America/Phoenix,HBK,US,Holbrook,Arizona,Navajo County,AP
-HBN,,Flamingo,12.0,106.0,229,,Asia/Ho_Chi_Minh,HBN,VN,Tan Bien,Tay Ninh,,AP
-HBO,,Municipal,40.166668,-95.95,1010,,America/Chicago,HBO,US,Pawnee City,Nebraska,Pawnee County,AP
 HBQ,,Qilian Airport,38.009560449999995,100.63671075340743,10367,,Asia/Shanghai,HBQ,CN,Hongtu,Qinghai Sheng,,AP
 HBR,KHBR,Hobart,35.016666,-99.1,1541,,America/Chicago,HBR,US,Hobart,Oklahoma,Kiowa County,AP
 HBT,,Hafr Albatin,27.911552,45.522972,1368,,Asia/Colombo,HRI,LK,,,,AP
 HBU,ZMBS,Bulgan Hovd,46.100496899999996,91.5836487910197,3845,,Asia/Hovd,HBU,MN,Burenhayrhan,Hovd,Bulgan District,AP
 HBX,VOHB,Hubli Airport,15.360478350000001,75.07761238064964,2162,http://www.airportsindia.org.in/allAirports/hubli_generalinfo.jsp,Asia/Kolkata,HBX,IN,Hubli,Karnataka,Dharwad,AP
 HCA,KHCA,Howard County,32.30361,-101.43389,2542,http://www.mybigspring.com/pages/airport,America/Chicago,HCA,US,Big Spring,Texas,Howard County,AP
-HCB,,Shoal Cove,55.45,-131.28334,150,,America/Anchorage,HCB,US,,,,AP
 HCC,1B1,Columbia County,42.29045015,-73.71160128274613,190,,America/New_York,HCC,US,Stottville,New York,Columbia County,AP
 HCJ,ZGHC,Hechi Jinchengjiang Airport,24.8048431,107.71074985180161,2125,,Asia/Shanghai,HCJ,CN,Nandan Chengguanzhen,Guangxi Zhuangzu Zizhiqu,,AP
 HCM,HCME,Eil,7.916667,49.8,452,,Africa/Mogadishu,HCM,SO,Eyl,Nugaal,,AP
@@ -3056,7 +3046,6 @@ HCQ,YHLC,Halls Creek,-18.23649795,127.66458487725606,1315,,Australia/Perth,HCQ,A
 HCR,PAHC,Holy Cross Airport,62.1908445,-159.7729269,75,,America/Anchorage,HCR,US,,,,AP
 HCW,KCQW,Cheraw,34.7,-79.88333,157,,America/New_York,HCW,US,Cheraw,South Carolina,Chesterfield County,AP
 HCZ,ZGCZ,Chenzhou Beihu Airport,25.75482855,112.84966005166282,1059,,Asia/Shanghai,HCZ,CN,Chenzhou,Hunan,,AP
-HDA,,Hidden Falls,57.2,-134.85,0,,America/Sitka,HDA,US,,,,AP
 HDB,ETIE,Airfield Heidelberg,49.3933,8.6525,780,,Europe/Berlin,HDB,DE,Heidelberg,,,AP
 HDD,OPKD,Hyderabad,25.319433349999997,68.36835559267595,141,,Asia/Karachi,HDD,PK,Kotri,Sindh,,AP
 HDE,KHDE,Brewster Field,40.4518458,-99.33835078099264,2303,,America/Chicago,HDE,US,Holdrege,Nebraska,Phelps County,AP
@@ -3079,15 +3068,11 @@ HEI,EDXB,Heide-Buesum,54.155556,8.902778,26,http://www.edxb.de,Europe/Berlin,HEI
 HEK,ZYHE,Heihe Airport,50.216667,127.433334,547,,Asia/Shanghai,HEK,CN,Xinfu,Heilongjiang Sheng,,AP
 HEL,EFHK,Helsinki-Vantaa Airport,60.32135905,24.947206800038444,173,http://www.finavia.fi/en/helsinki-airport,Europe/Helsinki,HEL,FI,,,,AP
 HEM,EFHF,Helsinki-malmi,60.2521109,25.0437312,49,,Europe/Helsinki,HEL,FI,,,,AP
-HEN,,Hendon,51.583332,-0.233333,269,,Europe/Helsinki,HEL,FI,Hendon,England,Greater London,AP
 HEO,AYHG,Haelogo,-9.13662165,147.59857131851487,3188,,Pacific/Port_Moresby,HEO,PG,,,,AP
 HER,LGIR,Heraklion Airport,35.3363305,25.1742268,101,,Europe/Athens,HER,GR,Nea Alikarnassos,Crete,Nomos Irakleiou,AP
 HES,KHRI,State,45.85,-119.28333,442,,America/Los_Angeles,HES,US,Hermiston,Oregon,Umatilla County,AP
 HET,ZBHH,Hohhot Baita International Airport,40.850898099999995,111.81798726025258,3487,http://www.hhhtbtjc.com/,Asia/Shanghai,HET,CN,Haoxinying,Inner Mongolia,,AP
-HEV,,Huelva,37.266666,-6.95,59,,Europe/Madrid,HEV,ES,Huelva,Andalusia,Provincia de Huelva,AP
 HEW,LGAT,Hengdian Airport,29.1257754,120.24493415336624,334,,Asia/Shanghai,HEW,CN,Nanshi,Zhejiang Sheng,,AP
-HEX,,Santo Domingo Herrera,18.475,-69.975,177,,America/Santo_Domingo,SDQ,DO,,,,AP
-HEY,,Hanchey Army Heliport,31.416668,-84.53333,190,,America/Chicago,OZR,US,Morgan,Georgia,Calhoun County,AP
 HEZ,KHEZ,Hardy-Anders,31.614721,-91.29639,239,https://www.adamscountyms.net/natchez-adams-county-airport,America/Chicago,HEZ,US,Morgantown,Mississippi,Adams County,AP
 HFA,LLHA,Haifa Airport,32.8105658,35.043082565539606,29,http://www.iaa.gov.il/Rashat/en-US/Airports/Haifa/,Asia/Jerusalem,HFA,IL,Qiryat Mozqin,Haifa,,AP
 HFD,KHFD,Brainard,41.7378691,-72.64876748368077,39,,America/New_York,HFD,US,Wethersfield,Connecticut,Hartford County,AP
@@ -3106,14 +3091,12 @@ HGN,VTCH,Mae Hong Son Airport,19.3010716,97.97606956686425,875,,Asia/Bangkok,HGN
 HGO,DIKO,Korhogo Airport,9.413889,-5.616667,1236,,Africa/Abidjan,HGO,CI,Korhogo,Savanes,,AP
 HGR,KHGR,Wash. County Regional Airport,39.70778,-77.73,675,,America/New_York,HGR,US,State Line,Pennsylvania,Franklin County,AP
 HGS,GFHA,Hastings,8.393056,-13.13,75,,Africa/Freetown,FNA,SL,Hastings,Western Area,,AP
-HGT,,Hunter AAF,35.966667,-121.15,977,,America/Los_Angeles,HGT,US,,,,AP
 HGU,AYMH,Mount Hagen Airport,-5.8275371,144.29964153501777,5380,,Pacific/Port_Moresby,HGU,PG,Mount Hagen,Western Highlands,Hagen,AP
 HGZ,2AK6,Hogatza,66.1849596,-155.7047114,439,,America/Anchorage,HGZ,US,,,,AP
 HHE,RJSH,Hachinohe,40.5541994,141.468868,124,,Asia/Tokyo,HHE,JP,Uchimaru,Aomori,Hachinohe Shi,AP
 HHH,KHXD,Hilton Head Airport,32.22564625,-80.69610111140818,104,,America/New_York,HHH,US,Hilton Head Island,South Carolina,Beaufort County,AP
 HHI,PHHI,Wheeler AFB,21.5,-158.03334,869,,Pacific/Honolulu,HHI,US,Wahiawa,Hawaii,Honolulu County,AP
 HHN,EDFH,Frankfurt - Hahn Airport,49.944633350000004,7.261210336785306,1692,,Europe/Berlin,FRA,DE,Lautzenhausen,Rheinland-Pfalz,,AP
-HHP,,H K Heliport,22.318056,114.2,22,,Asia/Hong_Kong,HKG,HK,,,,AP
 HHQ,VTPH,Hua Hin Airport,12.636825250000001,99.9510244942222,26,,Asia/Bangkok,HHQ,TH,Hua Hin,Prachuap Khiri Khan,,AP
 HHR,KHHR,Hawthorne,33.926945,-118.33639,62,,America/Los_Angeles,HHR,US,Hawthorne,California,Los Angeles County,AP
 HHZ,NTGH,Hikueru,-17.533333,-142.53334,0,,Pacific/Tahiti,HHZ,PF,,,,AP
@@ -3123,17 +3106,14 @@ HID,YHID,Horn Island Airport,-10.586416400000001,142.2862673040163,29,,Australia
 HIE,KHIE,Regional,44.365833,-71.548615,1026,http://www.mountwashingtonairport.com/,America/New_York,HIE,US,Whitefield,New Hampshire,Coos County,AP
 HIF,KHIF,Hill AFB,41.216667,-111.96667,4347,http://www.hill.af.mil/,America/Denver,OGD,US,Ogden,Utah,Weber County,AP
 HIG,YHHY,Highbury,-16.4244003,143.1459961,334,,Australia/Brisbane,HIG,AU,,,,AP
-HIH,,Hook Island,-20.166668,148.95,0,,Australia/Brisbane,HIH,AU,,,,AP
 HII,KHII,Municipal,34.568333,-114.35528,741,,America/Phoenix,HII,US,Desert Hills,Arizona,Mohave County,AP
 HIJ,RJOA,Hiroshima Airport,34.437479100000004,132.91951481722555,1076,,Asia/Tokyo,HIJ,JP,Takehara,Hiroshima,,AP
-HIK,,Hickam AFB,21.316668,-157.86667,39,,Pacific/Honolulu,HNL,US,Honolulu,Hawaii,Honolulu County,AP
 HIL,HASL,Shillavo,6.083333,44.766666,1269,,Africa/Addis_Ababa,HIL,ET,,,,AP
 HIM,VCCH,Hingurakgoda,8.0407681,80.9516787,219,http://www.airforce.lk/pages.php?pages=hingurakgoda,Asia/Colombo,HIM,LK,Polonnaruwa,North Central,,AP
 HIN,RKPS,Sacheon Airport,35.0921956,128.08665041662874,36,,Asia/Seoul,HIN,KR,Chinju,Gyeongsangnam-do,,AP
 HIO,KHIO,Portland,45.516666,-122.98333,160,http://www.flypdx.com/Airports/Hillsboro/,America/Los_Angeles,HIO,US,Hillsboro,Oregon,Washington County,AP
 HIP,YHDY,Headingly,-21.3221345,138.2954338,593,,Australia/Brisbane,HIP,AU,,,,AP
 HIR,AGGH,Honiara International Airport,-9.429441749999999,160.04987604652325,22,,Pacific/Guadalcanal,HIR,SB,,,,AP
-HIS,,Hayman Island,-20.066668,148.86667,0,,Australia/Lindeman,HIS,AU,,,,AP
 HIT,AYHO,Haivaro,-6.94283805,143.0551414177596,157,,Pacific/Port_Moresby,HIT,PG,,,,AP
 HIW,RJBH,Hiroshima West,34.36361,132.41638,19,,Asia/Tokyo,HIJ,JP,Hiroshima-shi,Hiroshima,,AP
 HJB,ZWHJ,Hejing Bayinbuluke Airport,42.9766,83.9729,8240,,Asia/Urumqi,HJB,CN,,,,AP
@@ -3168,10 +3148,8 @@ HLP,WIHH,Halim Perdanakusuma Airport,-6.2630208,106.8989505677548,55,http://www.
 HLR,KHLR,Fort Hood AAF,31.116667,-97.73333,797,,America/Chicago,ILE,US,Killeen,Texas,Bell County,AP
 HLS,YSTH,St Helens,-41.266666,148.25,239,,Australia/Hobart,HLS,AU,St Helens,Tasmania,Break O'Day,AP
 HLT,YHML,Hamilton,-37.646135400000006,142.0607158889008,761,,Australia/Melbourne,HLT,AU,Hamilton,Victoria,Southern Grampians,AP
-HLU,,Houailou,-21.033333,166.06667,0,,Pacific/Noumea,HLU,NC,Canala,North Province,Canala,AP
 HLV,,Helenvale,-15.6860941,145.2188078,485,,Australia/Brisbane,HLV,AU,,,,AP
 HLW,FAHL,Hluhluwe,-28.01605505,32.27510193785516,255,,Africa/Johannesburg,HLW,ZA,,,,AP
-HLY,,Anglesey Airport,53.3,-4.633333,55,,Europe/London,HLY,GB,Holyhead,Wales,Anglesey,AP
 HLZ,NZHN,Hamilton International Airport,-37.8649356,175.3315424211442,98,http://www.hamiltonairport.co.nz/,Pacific/Auckland,HLZ,NZ,Hamilton,Waikato,Hamilton City,AP
 HMA,USHH,Khanty-Mansiysk Airport,61.0289346,69.09482038194037,114,,Asia/Yekaterinburg,HMA,RU,Khanty-Mansiysk,Khanty-Mansiyskiy Avtonomnyy Okrug,,AP
 HMB,HESG,Mubarak International Airport,26.3417454,31.731065840096637,324,,Africa/Cairo,HMB,EG,Al Manshah,Suhaj,,AP
@@ -3190,15 +3168,12 @@ HNA,RJSI,Hanamaki Airport,39.4265171,141.13528215177976,255,,Asia/Tokyo,HNA,JP,H
 HNB,KHNB,Municipal,38.3,-86.95,501,http://huntingburgairport.com/,America/Indiana/Vincennes,HNB,US,Huntingburg,Indiana,Dubois County,AP
 HNC,KHSE,Hatteras,35.216667,-75.7,0,http://www.outerbanks.com/billy-mitchel-airport.html,America/New_York,HNC,US,Buxton,North Carolina,Dare County,AP
 HND,RJTT,Haneda Airport,35.54572095,139.78058713123818,22,http://www.haneda-airport.jp/,Asia/Tokyo,TYO,JP,Kawasaki,Kanagawa,Kawasaki-shi,AP
-HNE,,Tahneta Pass,61.8852019,-147.3349662,2942,,America/Anchorage,HNE,US,,,,AP
-HNG,,Hienghene,-20.666668,164.9,626,,Pacific/Noumea,HNG,NC,Hienghene,North Province,Hienghene,AP
 HNH,PAOH,Hoonah Airport,58.0977585,-135.4118093,19,,America/Juneau,HNH,US,,,,AP
 HNI,AYHE,Heiweni,22.213057,159.44695,3480,,Pacific/Port_Moresby,HNI,PG,Enewetak,Enewetak Atoll,,AP
 HNL,PHNL,Honolulu International Airport,21.32040435,-157.9173135198164,45,http://airports.hawaii.gov/hnl/,Pacific/Honolulu,HNL,US,Hickam Field,Hawaii,Honolulu County,AP
 HNM,PHHN,Hana Airport,20.7950029,-156.01442472183896,42,,Pacific/Honolulu,HNM,US,Hana,Hawaii,Maui County,AP
 HNN,AYHH,Honinabi,-6.133333,142.23334,495,,Pacific/Port_Moresby,HNN,PG,,,,AP
 HNS,PAHN,Haines Municipal Airport,59.245834,-135.51889,55,,America/Juneau,HNS,US,,,,AP
-HNX,,Hanna,41.833332,-106.5,7155,,America/Denver,HNX,US,,,,AP
 HNY,ZGHY,Hengyang Nanyue Airport,26.85,112.5,193,,Asia/Shanghai,HNY,CN,Hengyang,Hunan,Hengyang Shi,AP
 HOA,HKHO,Hola,-1.0,40.0,344,,Africa/Nairobi,HOA,KE,Hola,Tana River,,AP
 HOB,KHOB,Lea County Airport,32.68861,-103.21694,3641,,America/Denver,HOB,US,Hobbs,New Mexico,Lea County,AP

--- a/airports.csv
+++ b/airports.csv
@@ -3765,30 +3765,20 @@ JLX,,Union Station Heliport,34.166668,-118.333336,554,,America/Los_Angeles,LAX,U
 JMA,,Marriot Astrodome,29.983334,-95.34,121,,America/Chicago,HOU,US,Aldine,Texas,Harris County,AP
 JMB,,Jamba,-14.6981594,16.0643943,4914,,Africa/Luanda,JMB,AO,Caconda,Huila,,AP
 JMC,,Marin County,37.878613,-122.50972,0,,America/Los_Angeles,JMC,US,Marin City,California,Marin County,AP
-JMD,,Market Centre Heliport,32.8,-97.333336,561,,America/Chicago,DFW,US,,,,AP
-JMH,,Marriott Heliport,42.04783305,-88.05265951601996,721,,America/Chicago,JMH,US,Schaumburg,Illinois,Cook County,AP
 JMJ,ZPJM,Lancang Jingmai Airport,22.4162629,99.78555418663683,4347,,Asia/Shanghai,JMJ,CN,Menglang,Yunnan,,AP
 JMK,LGMK,Mikonos Airport,37.43499285,25.347326478108187,357,,Europe/Athens,JMK,GR,Mykonos,South Aegean,Nomos Kykladon,AP
-JMM,,Malmo Harbour Heliport,55.6,13.0,39,,Europe/Stockholm,MMA,SE,,,,AP
-JMN,,Municipal Heliport,44.166668,-94.01667,797,,America/Chicago,MKT,US,Mankato,Minnesota,Blue Earth County,AP
 JMO,VNJS,Jomsom,28.7803407,83.72299188531906,8982,,Asia/Kathmandu,JMO,NP,Jomsom,Western Region,Dhawalagiri Zone,AP
 JMR,SBMI,Maricá Airport,-22.918056,-42.828889,5,,America/Sao_Paulo,JMR,BR,,,,AP
 JMS,KJMS,Jamestown Airport,46.93,-98.67833,1473,,America/Chicago,JMS,US,Jamestown,North Dakota,Stutsman County,AP
 JMU,ZYJM,Jiamusi Airport,46.843340850000004,130.46148538753062,249,,Asia/Shanghai,JMU,CN,Songjiang,Heilongjiang Sheng,,AP
-JMY,,Mammy Yoko Heliport,8.483333,-13.266667,360,,Africa/Freetown,FNA,SL,Freetown,Western Area,,AP
 JNA,SNJN,Januaria,-15.473317399999999,-44.38438081278936,1571,,America/Sao_Paulo,JNA,BR,Januaria,Minas Gerais,Januaria,AP
 JNB,FAOR,O.R. Tambo International Airport,-26.13601315,28.244977230368022,5472,https://www.airports.co.za/airports/or-tambo-international-airport/,Africa/Johannesburg,JNB,ZA,Modderfontein,Gauteng,City of Johannesburg Metropolitan Municipality,AP
 JNG,ZSJG,Jining Airport,35.416668,116.53333,141,,Asia/Shanghai,JNG,CN,Jining,Shandong Sheng,,AP
-JNH,,North Park Inn Heliport,32.816666,-97.35,659,,America/Chicago,DFW,US,Blue Mound,Texas,Tarrant County,AP
 JNI,SAAJ,Junin,-34.583332,-60.966667,275,,America/Argentina/Buenos_Aires,JNI,AR,Junin,Buenos Aires,Partido de Junin,AP
 JNJ,OOJA,Jaaluni,19.4749,57.3083,538,,Asia/Muscat,JNJ,OM,,,,AP
-JNN,,Nanortalik,60.134167,-45.233612,0,,America/Godthab,JNN,GL,,,,AP
-JNP,,Heliport,33.61667,-117.933334,0,,America/Los_Angeles,JNP,US,Newport Beach,California,Orange County,AP
-JNS,,Heliport,60.916668,-46.05,0,,America/Godthab,JNS,GL,,,,AP
 JNU,PAJN,Juneau International Airport,58.3566191,-134.58019300175383,21,,America/Juneau,JNU,US,Juneau,Alaska,,AP
 JNX,LGNX,Naxos Airport,37.08109625,25.368368326596347,10,,Europe/Athens,JNX,GR,Naxos,South Aegean,Nomos Kykladon,AP
 JNZ,ZYJZ,Liaoning Province Airport,41.11667,121.01667,0,,Asia/Shanghai,JNZ,CN,Wanghu,Liaoning,,AP
-JOC,,Centerport Heliport,33.666668,-117.869446,0,,America/Los_Angeles,SNA,US,,,,AP
 JOE,EFJO,Joensuu Airport,62.659663949999995,29.621541792964734,398,http://www.finavia.fi/en/joensuu/,Europe/Helsinki,JOE,FI,Joensuu,North Karelia,Joensuu,AP
 JOG,WAHH,Adisutjipto International Airport,-7.793306149999999,110.42680947529018,379,http://adisutjipto-airport.co.id/,Asia/Jakarta,JOG,ID,Depok,Daerah Istimewa Yogyakarta,,AP
 JOH,FAPJ,Port Saint Johns,-31.616667,29.533333,1227,,Africa/Johannesburg,JOH,ZA,Port Saint John's,Eastern Cape,OR Tambo District Municipality,AP
@@ -3797,46 +3787,31 @@ JOJ,,Doris Lake Aerodrome,68.125278,-106.585278,72,,America/Cambridge_Bay,UZM,CA
 JOK,UWKJ,Yoshkar-Ola Airport,56.706104800000006,47.8973702593122,348,,Europe/Moscow,JOK,RU,Yoshkar-Ola,Mariy-El,,AP
 JOL,RPMJ,Jolo,6.053464,121.01270615673849,118,,Asia/Manila,JOL,PH,Jolo,Autonomous Region in Muslim Mindanao,Province of Sulu,AP
 JOM,HTNJ,Njombe,-9.3588371,34.77796910746214,6400,,Africa/Dar_es_Salaam,JOM,TZ,Njombe,Njombe,,AP
-JON,,Johnston Island,16.72862225,-169.5326128191757,0,,Pacific/Johnston,JON,UM,,,,AP
 JOP,AYJS,Josephstaal,-4.74841855,145.00650776801166,250,,Pacific/Port_Moresby,JOP,PG,,,,AP
-JOR,,The City Heliport,33.783333,-117.85,0,,America/Los_Angeles,JOR,US,Orange,California,Orange County,AP
 JOS,DNJO,Jos Airport,9.868407600000001,8.88721124329111,4232,http://www.faannigeria.org/nigeria-airport.php?airport=15,Africa/Lagos,JOS,NG,Jos,Plateau,,AP
 JOT,KJOT,Municipal,41.533333,-88.083336,582,http://www.jolietpark.org/index.php/facilities/joliet-regional-airport,America/Chicago,JOT,US,Joliet,Illinois,Will County,AP
 JPA,SBJP,Presidente Castro Pinto International Airport,-7.148930699999999,-34.95030583440195,217,,America/Fortaleza,JPA,BR,Bayeux,Paraiba,Bayeux,AP
-JPD,,Heliport,34.15,-118.15,0,,America/Los_Angeles,JPD,US,Pasadena,California,Los Angeles County,AP
 JPE,SNEB,Nagib Demachki Airport,-3.019722,-47.316389,443,,America/Sao_Paulo,JPE,BR,Paragominas,,,AP
-JPN,,Pentagon Army,38.766666,-77.066666,0,,America/New_York,WAS,US,Groveton,Virginia,Fairfax County,AP
 JPO,SNTS,Brigadeiro Firmino Ayres Airport,-7.037496939556,-37.25184761766,850,,America/Recife,NVM,BR,Patos,,,AP
 JPR,SBJI,Ji-Parana Airport,-10.870556,-61.84667,598,,America/Porto_Velho,JPR,BR,Ji Parana,Rondonia,Ji-Parana,AP
-JPT,,Park Ten Heliport,29.786388,-95.81167,0,,America/Chicago,HOU,US,Katy,Texas,Harris County,AP
-JPU,,La Defense Heliport,48.86667,2.333333,0,,Europe/Paris,PAR,FR,,,,AP
 JPY,SDTK,Paraty Airport,-23.224444,-44.720278,10,,America/Sao_Paulo,JPY,BR,Paraty,,,AP
 JQA,BGUQ,Qaarsut Airport,70.7344416,-52.698953503271895,289,,America/Godthab,JQA,GL,,,,AP
 JQE,MPJE,Jaque Airport,7.5,-78.166664,29,,America/Panama,JQE,PA,Jaque,Darien,,AP
-JRA,,West 30th St Heliport,40.755284950000004,-74.00674338577971,0,,America/New_York,NYC,US,,,,AP
-JRC,,Municipalcipal Heliport,44.016666,-92.46667,0,,America/Chicago,RST,US,Rochester,Minnesota,Olmsted County,AP
-JRE,,East 60th Street Heliport,40.74238615,-73.97207729134186,0,,America/New_York,NYC,US,,,,AP
 JRF,PHJR,Kalaeloa,21.30863315,-158.07260091830352,30,http://hawaii.gov/hnl/airport-information/kalaeloa-airport-jrf,Pacific/Honolulu,JRF,US,,,,AP
 JRG,VEJH,Jharsuguda Airport,21.91594295,84.05050482566077,751,,Asia/Kolkata,JRG,IN,Jharsuguda,Odisha,Jharsuguda,AP
 JRH,VEJT,Rowriah Airport,26.72934295,94.1720966824326,311,http://aai.aero/allAirports/jorhat_airpo_gi.jsp,Asia/Kolkata,JRH,IN,Jorhat,Assam,Jorhat,AP
 JRJ,,Ganzhou Ruijin Airport,25.9608,116.0775,765,,Asia/Shanghai,JRJ,CN,,,,AP
-JRK,,Arsuk,61.166668,-48.416668,0,,America/Godthab,JRK,GL,Paamiut,Sermersooq,,AP
 JRN,SWJU,Juruena,-10.314160600000001,-58.49488557867951,525,,America/Cuiaba,JRN,BR,,,,AP
 JRO,HTKJ,Kilimanjaro International Airport,-3.4280793999999997,37.076288891574904,2932,http://www.kilimanjaroairport.co.tz/,Africa/Dar_es_Salaam,JRO,TZ,Merelani,Arusha,,AP
-JRS,LLJR,Atarot,31.8651161,35.2192424,2485,,Asia/Jerusalem,JRS,IL,Qalandiya,West Bank,,AP
 JRT,,Juruti Airport,-2.1866669655,-56.0902786255,0,,America/Manaus,JRT,BR,Juruti,Para,Juruti,AP
 JSA,VIJR,Jaisalmer,26.916668,70.9,751,,Asia/Kolkata,JSA,IN,Jaisalmer,Rajasthan,Jaisalmer,AP
 JSB,SWBE,Walfrido Salmito de Almeida Airport,-4.05,-40.883333,2874,,America/Fortaleza,JSB,BR,São Benedito,Ceará,,AP
-JSD,,Sikorsky Heliport,41.2,-73.13333,0,,America/New_York,JSD,US,Stratford,Connecticut,Fairfield County,AP
-JSG,,San Rafael Heliport,37.966667,-122.53333,0,,America/Los_Angeles,SRF,US,San Rafael,California,Marin County,AP
 JSH,LGST,Sitia Airport,35.2161444,26.100884020397434,376,,Europe/Athens,JSH,GR,Siteia,Crete,Nomos Lasithiou,AP
 JSI,LGSK,Skiathos Airport,39.17848895,23.50318526783782,54,,Europe/Athens,JSI,GR,Skiathos,Thessaly,Nomos Magnisias,AP
 JSJ,ZYJS,Jiansanjiang Shidi Airport,47.1066465,132.6632288591807,0,,Asia/Shanghai,JSJ,CN,Fujin,Heilongjiang Sheng,,AP
 JSK,OIZJ,Jask Airport,25.65476,57.80172,29,,Asia/Tehran,JSK,IR,Jask,Hormozgan,,AP
-JSL,,Steel Pier Heliport,39.333332,-74.45,0,,America/New_York,AIY,US,Ventnor City,New Jersey,Atlantic County,AP
 JSM,SAWS,Jose De San Martin,-44.04784775,-70.44501939480728,2407,,America/Argentina/Catamarca,JSM,AR,Jose de San Martin,Chubut,,AP
 JSO,,Sodertalje Heliport,59.2,17.65,0,,Europe/Stockholm,JSO,SE,,,,AP
-JSP,,Seogwipo Heliport,33.483334,126.566666,0,,Asia/Seoul,CJU,KR,Jeju-si,Jeju-do,,AP
 JSR,VGJR,Jessore Airport,23.1831797,89.1611447,20,,Asia/Dhaka,JSR,BD,Jessore,Khulna,,AP
 JST,KJST,Cambria County Airport,40.31459165,-78.83353249226279,2284,,America/New_York,JST,US,Geistown,Pennsylvania,Cambria County,AP
 JSU,BGMQ,Heliport,65.416664,-52.9,91,,America/Godthab,JSU,GL,Maniitsoq,Qeqqata,,AP

--- a/airports.csv
+++ b/airports.csv
@@ -3676,21 +3676,15 @@ JCO,,Heliport,36.016666,14.333333,42,,Europe/Malta,JCO,MT,Qala,Il-Qala,,AP
 JCR,SBEK,Jacareacanga,-5.983333,-57.533333,557,,America/Santarem,JCR,BR,,,,AP
 JCS,SNWS,Aeroporto De Crateus Airport,-5.21230869969,-40.7045819389,1026,http://www.crateus.ce.gov.br/,America/Fortaleza,JCS,BR,Crateus,,,AP
 JCT,KJCT,Kimble County,30.510357550000002,-99.76556102069245,1666,,America/Chicago,JCT,US,Junction,Texas,Kimble County,AP
-JCU,,Ceuta Heliport,35.899166,-5.338333,0,,Africa/Ceuta,JCU,ES,Ceuta,Ceuta,Ceuta,AP
 JCY,0TE7,Johnson,30.283333,-98.416664,1200,,America/Chicago,JCY,US,Johnson City,Texas,Blanco County,AP
 JDA,KGCD,John Day,44.403653399999996,-118.97729130421767,3638,,America/Los_Angeles,JDA,US,John Day,Oregon,Grant County,AP
-JDB,,Downtown Heliport,32.766666,-97.316666,518,,America/Chicago,DFW,US,Fort Worth,Texas,Tarrant County,AP
 JDE,,Jiande Qiandaohu Airport,29.354412074477,119.18551273837,180,,Asia/Shanghai,JDE,CN,Jiande,,,AP
 JDF,SBJF,Francisco De Assis,-21.75,-43.333332,2562,,America/Sao_Paulo,JDF,BR,Juiz de Fora,Minas Gerais,Juiz De Fora,AP
 JDG,RKPD,Jeongseok,33.3926049,126.71186447715885,1053,,Asia/Seoul,JDG,KR,Seogwipo,Jeju-do,,AP
 JDH,VIJO,Jodhpur Airport,26.263920249999998,73.05054509038675,751,,Asia/Kolkata,JDH,IN,Jodhpur,Rajasthan,Jodhpur,AP
-JDM,,Miami Downtown Heliport,25.75,-80.25,65,,America/New_York,MIA,US,Coral Gables,Florida,Miami-Dade County,AP
 JDN,KJDN,Jordan,47.316666,-106.88333,2624,,America/Denver,JDN,US,Jordan,Montana,Garfield County,AP
 JDO,SBJU,Orlando Bezerra de Menezes Airport,-7.2,-39.316666,1243,,America/Fortaleza,JDO,BR,Juazeiro do Norte,Ceara,Juazeiro Do Norte,AP
-JDP,,Heliport De Paris,48.816666,2.283333,255,,Europe/Paris,PAR,FR,Issy-les-Moulineaux,Ile-de-France,Departement des Hauts-de-Seine,AP
 JDR,SNJR,Sao Joao Del Rei,-21.0852396,-44.224610172835526,3057,,America/Sao_Paulo,JDR,BR,Tiradentes,Minas Gerais,Tiradentes,AP
-JDT,,Downtown Heliport,44.983334,-93.26667,902,,America/Chicago,MSP,US,Minneapolis,Minnesota,Hennepin County,AP
-JDY,,Heliport,33.933334,-118.11667,118,,America/Los_Angeles,JDY,US,Downey,California,Los Angeles County,AP
 JDZ,ZSJD,Jingdezhen Airport,29.3432402,117.17988248363616,147,,Asia/Shanghai,JDZ,CN,Hongyuan,Jiangxi Sheng,,AP
 JED,OEJN,King Abdulaziz International Airport,21.6836591,39.16367476310531,26,http://www.jed-airport.com/,Asia/Riyadh,JED,SA,Jeddah,Makkah,,AP
 JEE,MTJE,Jeremie,18.66309045,-74.16970398819535,177,,America/Port-au-Prince,JEE,HT,Jeremie,Grandans,,AP
@@ -3698,38 +3692,26 @@ JEF,KJEF,Memorial,38.59222,-92.15639,544,https://www.jeffcitymo.org/publicworks/
 JEG,BGAA,Aasiaat Airport,68.7218676,-52.784103450705786,39,http://airgreenland.com/om_rejsen/efter_rejsen/din_destination_/aasiaat/,America/Godthab,JEG,GL,,,,AP
 JEJ,,Jeh,7.5653501,168.9620056,45,,Pacific/Majuro,JEJ,MH,,,,AP
 JEK,FLJK,Jeki Airport,-15.6334,29.6036,1131,,Africa/Lusaka,JEK,ZM,Luangwa,Lusaka,,AP
-JEM,,Heliport,37.833332,-122.3,0,,America/Los_Angeles,JEM,US,Emeryville,California,Alameda County,AP
 JEQ,SNJK,Jequie,-13.8775218,-40.071268208841715,610,,America/Bahia,JEQ,BR,Jequie,Bahia,Jequie,AP
 JER,EGJJ,Jersey Airport,49.2055732,-2.1949438,298,http://www.jerseyairport.com/,Europe/Jersey,JER,JE,Saint Helier,St Helier,,AP
 JFK,KJFK,John F. Kennedy International Airport,40.642947899999996,-73.7793733748521,45,https://www.jfkairport.com/,America/New_York,NYC,US,Inwood,New York,Nassau County,AP
-JFM,,Heliport,-32.05,115.75,26,,Australia/Perth,JFM,AU,North Fremantle,Western Australia,Fremantle,AP
 JFN,KHZY,Ashtabula,41.733334,-80.76667,925,http://www.neohioregionalairport.com/,America/New_York,JFN,US,Jefferson,Ohio,Ashtabula County,AP
 JFR,BGPT,Paamiut Airport,62.014621250000005,-49.67085832613154,78,,America/Godthab,JFR,GL,,,,AP
 JGA,VAJM,Govardhanpur Airport,22.466835250000003,70.00708076073744,36,,Asia/Kolkata,JGA,IN,Bedi,Gujarat,Jamnagar,AP
 JGB,,Jagdalpur,19.0734828,82.03477402779657,1837,,Asia/Kolkata,JGB,IN,Jagdalpur,Chhattisgarh,Bastar,AP
 JGD,ZYJD,Jiagedaqi Airport,50.371759749999995,124.1158382750555,1167,,Asia/Shanghai,JGD,CN,Jagdaqi,Inner Mongolia,,AP
-JGE,,Heliport,34.9,128.68333,137,,Asia/Seoul,JGE,KR,Sinhyeon,Gyeongsangnam-do,,AP
-JGL,,Galleria Heliport,33.886112,-84.46694,961,,America/New_York,ATL,US,Vinings,Georgia,Cobb County,AP
 JGN,ZLJQ,Jiayuguan Airport,39.833332,98.416664,4960,,Asia/Shanghai,JGN,CN,Jiayuguan,Gansu Sheng,,AP
-JGO,,Qeqertarsuaq,69.25,-53.566666,0,,America/Godthab,JGO,GL,,,,AP
-JGQ,,Transco Twr Galleria,29.766666,-95.46667,104,,America/Chicago,HOU,US,Hunters Creek Village,Texas,Harris County,AP
-JGR,,Heliport,61.233334,-48.1,26,,America/Godthab,JGR,GL,,,,AP
 JGS,ZSJA,Ji'An/Jing Gang Shan Airport,26.899721,114.7375,219,,Asia/Shanghai,JGS,CN,Denglong,Jiangxi Sheng,,AP
-JGX,,Heliport,34.166668,-118.28333,492,,America/Los_Angeles,JGX,US,North Glendale,California,Los Angeles County,AP
 JHB,WMKJ,Senai Airport,1.605881,103.6482705,59,,Asia/Kuala_Lumpur,JHB,MY,Taman Senai,Johor,,AP
-JHC,,Island Heliport,40.783333,-74.1,36,,America/New_York,JHC,US,North Arlington,New Jersey,Bergen County,AP
-JHE,,Heliport,56.033333,12.7,19,,Europe/Stockholm,AGH,SE,,,,AP
 JHF,SBJH,São Paulo Catarina Executive Airport,-23.426886,-47.165658,2562,,America/Sao_Paulo,JHF,BR,São Roque,Sao Paulo,,AP
 JHG,ZPJH,Xishuangbanna Gasa Airport,21.9746108,100.76425763644288,1797,,Asia/Shanghai,JHG,CN,Jinghong,Yunnan,,AP
 JHL,CAL4,Albian,57.2329368,-111.4254582,964,,America/Edmonton,HZP,CA,,,,AP
 JHM,PHJH,Kapalua Airport,20.965572799999997,-156.6715646726954,223,,Pacific/Honolulu,JHM,US,Napili-Honokowai,Hawaii,Maui County,AP
 JHS,BGSS,Sisimiut Airport,66.9508865,-53.72691239490176,9,https://www.mit.gl/en/todays-flights/airports/sisimiut-airport/,America/Godthab,JHS,GL,,,,AP
 JHW,KJHW,Jamestown Airport,42.15277265,-79.26453974336357,1735,,America/New_York,JHW,US,Celoron,New York,Chautauqua County,AP
-JHY,,Hyatt Regency Heliport,42.36667,-71.102776,36,,America/New_York,JHY,US,Cambridge,Massachusetts,Middlesex County,AP
 JIA,SWJN,Juina,-11.5,-58.88333,1069,,America/Cuiaba,JIA,BR,,,,AP
 JIB,HDAM,Djibouti-Ambouli International Airport,11.54800385,43.15864050716333,29,,Africa/Djibouti,JIB,DJ,Djibouti,Djibouti,,AP
 JIC,ZLJC,Jinchuan Airport,38.54139000000001,102.3486172295005,4776,,Asia/Shanghai,JIC,CN,Jinchang,Gansu Sheng,Jinchang Shi,AP
-JID,,City Of Industry Heliport,34.0,-118.0,889,,America/Los_Angeles,LAX,US,Hacienda Heights,California,Los Angeles County,AP
 JIJ,HAJJ,Jigiga Airport,9.366667,42.766666,5570,,Africa/Addis_Ababa,JIJ,ET,Jijiga,Somali,,AP
 JIK,LGIK,Ikaria Airport,37.6829412,26.346215400974874,65,,Europe/Athens,JIK,GR,Agios Kirykos,North Aegean,Nomos Samou,AP
 JIL,ZYJL,Jilin,43.86667,126.65,859,,Asia/Shanghai,JIL,CN,Jilin,Jilin Sheng,,AP
@@ -3747,24 +3729,18 @@ JJG,SBJA,Jaguaruna Regional Airport,-28.66726125,-49.05437795338313,82,http://ww
 JJI,SPJI,Juanjui,-7.1661,-76.72659659021983,849,,America/Lima,JJI,PE,Juanjui,San Martin,Provincia de Mariscal Caceres,AP
 JJM,HKMK,Mulika Lodge Airport,0.233194,38.183334,2158,,Africa/Nairobi,JJM,KE,Maua,Isiolo,,AP
 JJN,ZSQZ,Quanzhou Jinjiang International Airport,24.79702915,118.58870501999499,29,,Asia/Shanghai,JJN,CN,Jinjiang,Fujian,,AP
-JJU,,Heliport,60.716667,-46.033333,0,,America/Godthab,JJU,GL,Qaqortoq,Kujalleq,,AP
 JKG,ESGJ,Axamo Airport,57.76018705,14.06703041585528,754,http://www.lfv.se/templates/LFV_AirportStartPage____1672.aspx,Europe/Stockholm,JKG,SE,Taberg,Joenkoeping,Jonkopings Kommun,AP
 JKH,LGHI,Chios Airport,38.3421243,26.140171285583204,29,http://www.hcaa-eleng.gr/chios.htm,Europe/Athens,JKH,GR,Chios,North Aegean,Chios,AP
 JKL,LGKY,Kalymnos Island National Airport,36.9632747,26.939981365194278,715,,Europe/Athens,JKL,GR,Kalymnos,South Aegean,Nomos Dodekanisou,AP
 JKR,VNJP,Janakpur Airport,26.710195149999997,85.92374733048763,203,,Asia/Kathmandu,JKR,NP,Janakpur,Central Region,,AP
 JKV,KJSO,Cherokee County,31.966667,-95.333336,620,,America/Chicago,JKV,US,Jacksonville,Texas,Cherokee County,AP
 JLA,JLA,Quartz Creek,60.483334,-149.85,633,,America/Anchorage,JLA,US,,,,AP
-JLB,,Long Beach Heliport,33.749293,-118.190323,16,,America/Los_Angeles,LGB,US,Long Beach,California,,AP
-JLD,,Heliport,56.05,12.7,108,,Europe/Stockholm,JLD,SE,Helsingborg,Skane,Helsingborg,AP
 JLG,VAJL,Jalgaon Airport,20.961944,75.626667,840,,Asia/Kolkata,JLG,IN,,,,AP
-JLH,,US Army Heliport,42.083332,-87.98333,708,,America/Chicago,JLH,US,Arlington Heights,Illinois,Cook County,AP
 JLN,KJLN,Joplin Airport,37.149723,-94.49778,944,,America/Chicago,JLN,US,Webb City,Missouri,Jasper County,AP
 JLR,VAJB,Jabalpur Airport,22.666668,79.925,1781,,Asia/Kolkata,JLR,IN,Ghansor,Madhya Pradesh,Seoni,AP
 JLS,SDJL,Jales,-20.166668,-50.55,1532,,America/Sao_Paulo,JLS,BR,Jales,Sao Paulo,Jales,AP
-JLX,,Union Station Heliport,34.166668,-118.333336,554,,America/Los_Angeles,LAX,US,Burbank,California,Los Angeles County,AP
 JMA,,Marriot Astrodome,29.983334,-95.34,121,,America/Chicago,HOU,US,Aldine,Texas,Harris County,AP
 JMB,,Jamba,-14.6981594,16.0643943,4914,,Africa/Luanda,JMB,AO,Caconda,Huila,,AP
-JMC,,Marin County,37.878613,-122.50972,0,,America/Los_Angeles,JMC,US,Marin City,California,Marin County,AP
 JMJ,ZPJM,Lancang Jingmai Airport,22.4162629,99.78555418663683,4347,,Asia/Shanghai,JMJ,CN,Menglang,Yunnan,,AP
 JMK,LGMK,Mikonos Airport,37.43499285,25.347326478108187,357,,Europe/Athens,JMK,GR,Mykonos,South Aegean,Nomos Kykladon,AP
 JMO,VNJS,Jomsom,28.7803407,83.72299188531906,8982,,Asia/Kathmandu,JMO,NP,Jomsom,Western Region,Dhawalagiri Zone,AP

--- a/airports.csv
+++ b/airports.csv
@@ -1621,7 +1621,7 @@ CSS,SSCL,Cassilandia,-18.983334,-51.983334,1669,,America/Campo_Grande,CSS,BR,Cas
 CST,NFCS,Castaway,-17.5,177.5,0,,Pacific/Fiji,CST,FJ,Lautoka,Western,,AP
 CSU,SSSC,Santa Cruz Do Sul,-29.68380235,-52.41103406734325,626,,America/Sao_Paulo,CSU,BR,Santa Cruz do Sul,Rio Grande do Sul,Santa Cruz Do Sul,AP
 CSV,KCSV,Memorial,35.95111,-85.084724,1873,http://www.crossvilletn.gov/index.php/departments/airport,America/Chicago,CSV,US,Crossville,Tennessee,Cumberland County,AP
-CSW,,Colorado do Oeste,-13.019444,-61.168056,711,,America/Porto_Velho,CSW,BR,,,,AP
+CSW,MMSL,Cabo San Lucas International Airport,22.9475,-109.936944,666,,America/Mazatlan,CSW,MX,Los Cabos,Baja California Sur,,AP
 CSX,ZGHA,Changsha Huanghua Airport,28.190666049999997,113.21991433924589,45,,Asia/Shanghai,CSX,CN,,,,AP
 CSY,UWKS,Cheboksary Airport,56.13333,47.266666,416,,Europe/Moscow,CSY,RU,Cheboksary,Chuvashia,Cheboksarskiy Rayon,AP
 CSZ,SAZC,Brigadier Hector Ruiz,-37.433334,-61.88333,754,,America/Argentina/Buenos_Aires,CSZ,AR,Coronel Suarez,Buenos Aires,Partido de Coronel Suarez,AP
@@ -1688,7 +1688,7 @@ CVJ,MMCB,General Mariano Matamoros Airport,18.916668,-99.25,5003,,America/Mexico
 CVL,,Cape Vogel,-9.466667,150.5,741,,Pacific/Port_Moresby,CVL,PG,,,,AP
 CVM,MMCV,Ciudad Victoria Airport,23.713888,-98.96528,757,,America/Monterrey,CVM,MX,Ciudad Victoria,Tamaulipas,,AP
 CVN,KCVN,Clovis Municipal Airport,34.42584135,-103.07970767542656,4179,,America/Denver,CVN,US,Texico,New Mexico,Curry County,AP
-CVO,KCVO,Albany,44.63333,-123.11667,249,http://www.corvallisoregon.gov/index.aspx?page=160,America/Los_Angeles,CVO,US,Albany,Oregon,Linn County,AP
+CVO,KCVO,Corvallis Municipal Airport,44.497222,-123.289444,250,http://www.ci.corvallis.or.us/,America/Los_Angeles,CVO,US,Corvallis,Oregon,Corvallis,AP
 CVQ,YCAR,Carnarvon Airport,-24.883429,113.66358,32,,Australia/Perth,CVQ,AU,,,,AP
 CVR,,Hughes,33.975,-118.417,26,,America/Los_Angeles,CVR,US,Marina del Rey,California,Los Angeles County,AP
 CVS,KCVS,Cannon AFB,34.382445,-103.320967,4251,http://www.cannon.af.mil/,America/Denver,CVN,US,Cannon Air Force Base,New Mexico,Curry County,AP
@@ -2584,7 +2584,7 @@ FUK,RJFF,Fukuoka Airport,33.586802,130.44739386660302,32,http://www.fuk-ab.co.jp
 FUL,KFUL,Municipal,33.86667,-117.975,82,http://www.cityoffullerton.com/depts/airport/,America/Los_Angeles,FUL,US,Buena Park,California,Orange County,AP
 FUM,AYFU,Fuma,-6.393814949999999,142.43981673417176,462,,Pacific/Port_Moresby,FUM,PG,,,,AP
 FUN,NGFU,Funafuti Atol International Airport,-8.516667,179.20833,0,,Pacific/Funafuti,FUN,TV,Fakaifou Village,Funafuti,,AP
-FUO,ZGFS,Fuoshan Airport,23.133333,113.28333,62,,Asia/Shanghai,FUO,CN,Guangzhou,Guangdong,,AP
+FUO,ZGFS,Fuoshan Shadi Airport,23.133333,113.28333,62,,Asia/Shanghai,FUO,CN,Foshan,Guangdong,,AP
 FUT,NLWF,Futuna Island,-14.25,-178.15,0,,Pacific/Wallis,FUT,WF,Sigave,Circonscription de Sigave,,AP
 FVL,YFLO,Flora Valey,-18.283333,128.41667,1200,,Australia/Perth,FVL,AU,,,,AP
 FVM,VRMR,Fumawula,-0.309444,73.43278,26,,Indian/Maldives,FVM,MV,Fuvahmulah,Gnyaviyani Atoll,,AP
@@ -5446,7 +5446,6 @@ MVF,SBMS,Dixsept Rosado,-5.166667,-37.25,78,,America/Fortaleza,MVF,BR,Mossoro,Ri
 MVG,,Mevang,0.116667,11.083333,1102,,Africa/Libreville,MVG,GA,Ndjole,Moyen-Ogooue,,AP
 MVH,,Macksville,-30.75,152.9,29,,Australia/Sydney,MVH,AU,Macksville,New South Wales,Nambucca Shire,AP
 MVI,,Manetai,-6.0,155.33333,472,,Pacific/Port_Moresby,MVI,PG,,,,AP
-MVJ,,Marlboro,18.021667,-77.49528,2109,,America/Jamaica,MVJ,JM,Mandeville,Manchester,,AP
 MVK,YMUK,Mulka,-27.25,138.0,114,,Australia/Adelaide,MVK,AU,,,,AP
 MVL,KMVL,Morrisville-Stowe,44.53400725,-72.61420790118751,669,,America/New_York,MVL,US,Morrisville,Vermont,Lamoille County,AP
 MVM,,Monument Valley,36.702778,-110.23333,5718,,America/Shiprock,MVM,US,Kayenta,Arizona,Navajo County,AP
@@ -5478,7 +5477,6 @@ MWL,KMWL,Mineral Wells Airport,32.78175675,-98.06059143160783,944,http://www.min
 MWM,,Windom Municipal,43.9132906,-95.1094361,1371,,America/Chicago,MWM,US,Windom,Minnesota,Cottonwood County,AP
 MWN,HTMD,Mwadui,-3.55,33.6,3963,,Africa/Dar_es_Salaam,MWN,TZ,Mwadui,Shinyanga,,AP
 MWO,KMWO,Hook Field,39.53105985,-84.39794351164792,626,,America/New_York,MWO,US,Middletown,Ohio,Butler County,AP
-MWP,,Mountain,28.0,85.333336,8832,,Asia/Kathmandu,MWP,NP,,,,AP
 MWQ,VYMW,Magwe,20.166668,94.94111,288,,Asia/Rangoon,MWQ,MM,Magway,Magway,,AP
 MWR,,Motswari Airfield,-24.1903,31.3864,1174,,Africa/Johannesburg,MWR,ZA,,,,AP
 MWS,,Mount Wilson,34.216667,-118.066666,4619,,America/Los_Angeles,MWS,US,Sierra Madre,California,Los Angeles County,AP
@@ -5566,7 +5564,6 @@ MZX,,Mena,6.35,39.716667,4406,,Africa/Addis_Ababa,MZX,ET,Goba,Oromiya,,AP
 MZY,FAMO,Mossel Bay,-34.1563616,22.060188793545002,521,http://www.mosselbayaero.com/wmenu.php,Africa/Johannesburg,MZY,ZA,Mossel Bay,Western Cape,Eden District Municipality,AP
 MZZ,KMZZ,Marion,40.490833,-85.67944,839,http://kmzzairport.com/,America/Indiana/Indianapolis,MZZ,US,Jonesboro,Indiana,Grant County,AP
 NAA,YNBR,Narrabri,-30.3292011,149.8250651,725,http://narrabri.cfm.predelegation.com/index.cfm?page_id=1249,Australia/Sydney,NAA,AU,,,,AP
-NAB,,Albany NAS,31.583332,-84.166664,193,,America/New_York,ABY,US,Albany,Georgia,Dougherty County,AP
 NAC,YNRC,Naracoorte,-36.95,140.83333,236,,Australia/Adelaide,NAC,AU,Naracoorte,South Australia,Naracoorte and Lucindale,AP
 NAD,,Macanal,2.566667,-67.583333,301,,America/Bogota,NAD,CO,Maroa,Amazonas,Municipio Autonomo Maroa,AP
 NAE,DBBN,Natitingou,10.37708265,1.3599760824345344,1417,,Africa/Porto-Novo,NAE,BJ,Natitingou,Atakora,,AP
@@ -5601,8 +5598,6 @@ NBL,MPWN,San Blas,9.3,-79.0,1597,,America/Panama,NBL,PA,El Progreso,Panama,,AP
 NBN,FGAB,Annobón,-1.407638,5.62510323839779,0,,Africa/Malabo,NBN,GQ,Pale,Annobon,,AP
 NBO,HKJK,Jomo Kenyatta International Airport,-1.3168547,36.92904912198662,5272,http://www.kenyaairports.com/jkia/IndexJkia.php,Africa/Nairobi,NBO,KE,Pumwani,Nairobi Area,,AP
 NBS,ZYBS,Changbaishan Airport,42.0691726,127.60277214510086,2890,,Asia/Shanghai,NBS,CN,Manjiang,Jilin Sheng,,AP
-NBU,,NAS,39.55,-107.316666,6023,,America/Chicago,NBU,US,Glenwood Springs,Colorado,Garfield County,AP
-NBV,,Cana Brava,-17.383333,-45.86667,1722,,America/Sao_Paulo,NBV,BR,Joao Pinheiro,Minas Gerais,Joao Pinheiro,AP
 NBW,MUGM,Guantanamo NAS,20.166668,-75.23333,232,,America/Havana,GAO,CU,Guantanamo,Guantanamo,Municipio de Guantanamo,AP
 NBX,WABI,Nabire,-3.366667,135.43333,0,,Asia/Jayapura,NBX,ID,,,,AP
 NCA,MBNC,North Caicos,21.9157059,-71.9443193415783,42,,America/Grand_Turk,NCA,TC,,,,AP
@@ -5632,13 +5627,10 @@ NDK,,Namdrik Island,5.633333,168.11667,0,,Pacific/Majuro,NDK,MH,Namdrik,Namdrik 
 NDL,FEFN,Ndele,8.4247438,20.635557191670586,1578,,Africa/Bangui,NDL,CF,Ndele,Bamingui-Bangoran,,AP
 NDM,HAMN,Mendi,9.816667,35.083332,5400,,Africa/Addis_Ababa,NDM,ET,Mendi,Oromiya,,AP
 NDN,AYNC,Nadunumu,-9.14364895,147.684147735888,5055,,Pacific/Port_Moresby,NDN,PG,,,,AP
-NDO,,La Palma Del Condado,37.38333,-6.583333,259,,Europe/Madrid,NDO,ES,Villarrasa,Andalusia,Provincia de Huelva,AP
 NDR,GMMW,Nador International Airport,34.9876917,-3.036671157151174,577,,Africa/Casablanca,NDR,MA,Selouane,Oriental,Nador,AP
 NDS,YSAN,Sandstone,-27.9799995,119.2969971,1696,,Australia/Perth,NDS,AU,,,,AP
 NDU,FYRU,Rundu,-17.95681845,19.728350667774258,3559,,Africa/Windhoek,NDU,NA,Rundu,Kavango East,,AP
-NDV,,USN Heliport,38.86667,-77.0,19,,America/New_York,NDV,US,,,,AP
 NDY,EGES,Sanday,59.2504586,-2.5752648917172283,19,,Europe/London,NDY,GB,,,,AP
-NEA,,Brunswick Golden Isles,31.259811,-81.4639706620112,39,,America/New_York,NEA,US,Country Club Estates,Georgia,Glynn County,AP
 NEC,SAZO,Necochea,-38.566666,-58.75,26,,America/Argentina/Buenos_Aires,NEC,AR,Necochea,Buenos Aires,,AP
 NEF,UWUF,Neftekamsk,56.11364845,54.35040539230218,419,,Asia/Yekaterinburg,NEF,RU,Neftekamsk,Bashkortostan,,AP
 NEG,MKNG,Negril,18.3398797,-78.3360557,49,,America/Jamaica,NEG,JM,Negril,Westmoreland,,AP
@@ -5648,19 +5640,15 @@ NEK,HANK,Nekemt,9.066667,36.5,6794,,Africa/Addis_Ababa,NEK,ET,,,,AP
 NEL,KNEL,Naec,40.016666,-74.316666,98,,America/New_York,NEL,US,Lakehurst,New Jersey,Ocean County,AP
 NEN,KNEN,Olf Usn,30.316668,-81.85,82,,America/New_York,NEN,US,Baldwin,Florida,Duval County,AP
 NER,UELL,Neryungri Airport,56.65,124.6,2352,,Asia/Yakutsk,NER,RU,Neryungri,Sakha,,AP
-NES,,East 34th St Landing,40.743332,-73.975,39,,America/New_York,NYC,US,,,,AP
-NET,,New Bight,24.314824100000003,-75.45763803663925,36,,America/Nassau,NET,BS,,,,AP
 NEU,VLSN,Sam Neua,20.41856835,104.06710620098113,3185,,Asia/Vientiane,NEU,LA,Xam Nua,Houaphan,,AP
 NEV,TKPN,Newcastle Airport,17.205,-62.5925,22,,America/St_Kitts,NEV,KN,Newcastle,Saint James Windwa,,AP
 NEW,KNEW,Lakefront Airport,30.039444,-90.026665,36,http://www.lakefrontairport.com/,America/Chicago,MSY,US,Arabi,Louisiana,Saint Bernard Parish,AP
-NFB,,Detroit NAF,42.966667,-82.96667,764,,America/Detroit,MTC,US,Capac,Michigan,Saint Clair County,AP
 NFG,USRN,Nefteyugansk,61.13333,73.05,134,http://www.nuatc.ru/,Asia/Yekaterinburg,NFG,RU,Barsovo,Khanty-Mansiyskiy Avtonomnyy Okrug,,AP
 NFL,KNFL,Fallon Naval Air Station (Van Voorhis Field),39.41783,-118.69859,3960,http://www.cnic.navy.mil/regions/cnrsw/installations/nas_fallon.html,America/Los_Angeles,NFL,US,Fallon,Nevada,Churchill County,AP
 NFO,NFTO,Mata'aho,-15.571831,-175.62891795,141,,Pacific/Tongatapu,NFO,TO,,,,AP
 NFR,HLNR,Nafoora,29.2172182,21.5872796,111,,Africa/Tripoli,NFR,LY,Gialo,,,AP
 NGA,YYNG,Young,-34.25,148.25,1197,,Australia/Sydney,NGA,AU,Young,New South Wales,Young,AP
 NGB,ZSNB,Ningbo Airport,29.8261878,121.45840490871828,32,,Asia/Shanghai,NGB,CN,Gulin,Zhejiang Sheng,,AP
-NGC,,North Rim,36.38972,-112.129166,8756,,America/Phoenix,GCN,US,Grand Canyon,Arizona,Coconino County,AP
 NGD,TUPA,Captain Auguste George,18.716667,-64.3,236,,America/Tortola,NGD,VG,,,,AP
 NGE,FKKN,Ngaoundéré,7.35617015,13.558885789363384,3622,,Africa/Douala,NGE,CM,Ngaoundere,Adamaoua,,AP
 NGF,PHNG,Marine Corps Air Station Kaneohe Bay,21.445833,-157.769722,26,http://www.mcbhawaii.marines.mil/Units/SubordinateCommands/MarineCorpsAirStation.aspx,Pacific/Honolulu,NGF,US,Marine Corps Base Hawaii - MCBH,Hawaii,Honolulu County,AP
@@ -5676,7 +5664,6 @@ NGS,RJFU,Nagasaki Airport,32.917846,129.91545060447868,22,,Asia/Tokyo,NGS,JP,,,,
 NGU,KNGU,NAS Chambers,35.833332,-76.28333,39,,America/New_York,ORF,US,Columbia,North Carolina,Tyrrell County,AP
 NGW,,Cabaniss Field,27.783333,-97.4,42,,America/Chicago,CRP,US,Corpus Christi,Texas,Nueces County,AP
 NGX,VNMA,Manang,27.700556,85.36305,4347,,Asia/Kathmandu,NGX,NP,Kathmandu,Central Region,Bagmati Zone,AP
-NGZ,,NAS,37.766666,-122.25,85,,America/Los_Angeles,NGZ,US,Alameda,California,Alameda County,AP
 NHA,VVNT,Nha Trang,12.249573,109.1929837,52,,Asia/Ho_Chi_Minh,NHA,VN,Nha Trang,Khanh Hoa,,AP
 NHD,OMDM,Minhad AB,25.023756,55.373653,131,,Asia/Dubai,DXB,AE,Dubai,Dubai,,AP
 NHF,HSNW,New Halfa,15.3561652,35.7283939,1456,,Africa/Khartoum,NHF,SD,Aroma,Kassala,,AP
@@ -5689,7 +5676,6 @@ NHZ,KBXM,NAS,43.916668,-69.96667,45,http://mrra.us/brunswick-executive-airport/,
 NIA,GLNA,Nimba,7.4939464000000005,-8.584478839771435,1574,,Africa/Monrovia,NIA,LR,New Yekepa,Nimba,,AP
 NIB,PAFS,Nikolai,63.0182542,-154.3579666,472,,America/Anchorage,NIB,US,,,,AP
 NIC,LCNC,Nicosia International,35.1596193,33.2753522,725,,Asia/Nicosia,NIC,CY,Kato Deftera,Lefkosia,,AP
-NIE,,Niblack,55.066666,-132.15,134,,America/Anchorage,NIE,US,,,,AP
 NIF,YCNF,Nifty Airport,-21.6709193,121.588329,964,,Australia/Perth,NIF,AU,,,,AP
 NIG,NGNU,Nikunau,-1.31444,176.4100037,9,,Pacific/Tarawa,NIG,KI,,,,AP
 NIK,,Niokolo Koba,13.0523055,-12.7266741,265,,Africa/Dakar,NIK,SN,,,,AP
@@ -5721,7 +5707,6 @@ NKP,NTKU,Nakhon Phanom Airport,17.3886974,104.6446664,557,,Asia/Bangkok,NKP,TH,N
 NKS,FKAN,Nkongsamba,4.95,9.933333,2650,,Africa/Douala,NKS,CM,Nkongsamba,Littoral,,AP
 NKT,LTCV,Shirnak,37.363889,42.06,2030,,Europe/Istanbul,NKT,TR,Tililan,Sirnak,,AP
 NKU,FXNK,Nkaus,-29.5,28.0,8238,,Africa/Maseru,NKU,LS,,,,AP
-NKV,,Nichen Cove,55.85,-133.21666,0,,America/Anchorage,NKV,US,,,,AP
 NKX,KNKX,Miramar MS,32.86667,-117.11667,436,http://www.miramar.marines.mil/,America/Los_Angeles,SAN,US,Poway,California,San Diego County,AP
 NKY,FCBY,Nkayi,-4.2220518,13.2858039,534,,Africa/Brazzaville,NKY,CG,Kayes,Bouenza,,AP
 NLA,FLSK,Simon Mwansa Kapwepwe International Airport,-12.993449,28.665024,4156,,Africa/Lusaka,NLA,ZM,Ndola,Copperbelt,,AP
@@ -5754,7 +5739,6 @@ NMP,YNMN,New Moon,-20.166668,143.96666,1443,,Australia/Brisbane,NMP,AU,,,,AP
 NMR,YNAP,Nappa Merry,-27.6,141.11667,170,,Australia/Brisbane,NMR,AU,,,,AP
 NMS,VYNS,Namsang,20.89112305,97.73494550734442,3169,,Asia/Rangoon,NMS,MM,Taunggyi,Shan,,AP
 NMT,VYNU,Namtu,23.083332,97.4,2043,,Asia/Rangoon,NMT,MM,Lashio,Shan,,AP
-NMU,,Namu,8.0,168.13333,0,,Pacific/Majuro,NMU,MH,Loen,Namu Atoll,,AP
 NNA,GMMY,NAF,34.266666,-6.666667,0,,Africa/Casablanca,NNA,MA,Kenitra,Gharb-Chrarda-Beni Hssen,Kenitra Province,AP
 NNB,AGGT,Santa Ana Airport,-10.833333,162.5,0,,Pacific/Guadalcanal,NNB,SB,,,,AP
 NND,,Nangade,-11.083333,39.1,583,,Africa/Maputo,NND,MZ,Namalenga,Mtwara,,AP
@@ -5773,11 +5757,9 @@ NOB,MRNS,Nosara Beach,9.97733305,-85.65236200460156,59,,America/Costa_Rica,NOB,C
 NOC,EIKN,Ireland West Airport Knock,53.91159225,-8.81313884580053,652,http://www.irelandwestairport.com/,Europe/Dublin,NOC,IE,Swinford,Connaught,Maigh Eo,AP
 NOD,EDWS,Norden Norddeich Airport,53.583332,7.2,22,,Europe/Berlin,NOD,DE,Norden,Lower Saxony,,AP
 NOG,MMNG,Nogales,31.333332,-110.933334,3979,,America/Hermosillo,NOG,MX,,,,AP
-NOH,,Chicago NAS,41.880554,-87.61667,574,,America/Chicago,CHI,US,,,,AP
 NOI,,Novorossijsk,44.716667,37.766666,127,,Europe/Moscow,NOI,RU,Novorossiysk,Krasnodarskiy,,AP
 NOJ,USRO,Nojabrxsk Airport,63.17673,75.29459,400,,Asia/Yekaterinburg,NOJ,RU,Noyabrsk,Yamalo-Nenetskiy Avtonomnyy Okrug,,AP
 NOK,SWXV,Nova Xavantina,-14.698767,-52.348088000279134,997,,America/Cuiaba,NOK,BR,Araguaiana,Mato Grosso,Araguaiana,AP
-NOL,,Nakolik River,67.9,-160.71666,462,,America/Anchorage,NOL,US,,,,AP
 NOM,,Nomad River,-6.2939573,142.23412449302776,259,,Pacific/Port_Moresby,NOM,PG,,,,AP
 NON,NGTO,Nonouti,-0.680556,174.35,0,,Pacific/Tarawa,NON,KI,,,,AP
 NOO,,Naoro,-9.2,147.53334,2870,,Pacific/Port_Moresby,NOO,PG,,,,AP
@@ -5825,7 +5807,6 @@ NRT,RJAA,Narita International Airport,35.77587145,140.3933101399336,137,http://w
 NRY,,Newry,-16.016666,129.23334,236,,Australia/Darwin,NRY,AU,,,,AP
 NSB,,North SPB,25.775,-79.25,0,,America/Nassau,BIM,BS,Alice Town,Bimini,,AP
 NSE,KNSE,Whiting Field NAS,30.633333,-87.05,68,,America/Chicago,NSE,US,Milton,Florida,Santa Rosa County,AP
-NSF,,Andrews NAF,38.816666,-76.833336,190,,America/New_York,ADW,US,Mellwood,Maryland,Prince George's County,AP
 NSH,OINN,Now Shahr Airport,36.666668,51.5,-91,,Asia/Tehran,NSH,IR,Nowshahr,Mazandaran,Nowshahr,AP
 NSI,FKYS,Nsimalen Airport,3.7250788,11.552168664779966,2142,,Africa/Douala,YAO,CM,,,,AP
 NSK,UOOO,Noril'sk Airport,69.3087924,87.31467521266606,547,,Asia/Krasnoyarsk,NSK,RU,Kayyerkan,Krasnoyarskiy,,AP
@@ -5833,11 +5814,9 @@ NSL,KDVP,Slayton Municipal,43.984017300000005,-95.78246930183178,1410,http://www
 NSM,YNSM,Norseman,-32.2099991,121.7549973,833,,Australia/Perth,NSM,AU,,,,AP
 NSN,NZNS,Nelson Airport,-41.299976,173.22498,19,http://www.nelsonairport.co.nz/,Pacific/Auckland,NSN,NZ,Richmond,Tasman,Tasman District,AP
 NSO,YSCO,Scone,-32.0375693,150.8320286417641,721,,Australia/Sydney,NSO,AU,Muswellbrook,New South Wales,Muswellbrook,AP
-NSP,,NAF,14.5,120.9,0,,Asia/Manila,NSP,PH,Cavite City,Calabarzon,Province of Cavite,AP
 NSR,SWKY,São Raimundo Nonato Airport,-9.082778,-42.644444,1362,,America/Fortaleza,NSR,BR,São Raimundo Nonato,,,AP
 NST,VTSF,Nakhon Si Thammarat Airport,8.4701019,99.9566766,22,,Asia/Bangkok,NST,TH,Nakhon Si Thammarat,Nakhon Si Thammarat,,AP
 NSV,YNSH,Noosaville,-26.422261,153.06349594526466,16,,Australia/Brisbane,NSV,AU,Tewantin,Queensland,Sunshine Coast,AP
-NSX,,Hovercraft/Launch Pt,18.5,-64.36667,0,,America/Tortola,NSX,VG,,,,AP
 NSY,LICZ,NAS Sigonella,37.4,14.933333,36,,Europe/Rome,NSY,IT,Motta Sant'Anastasia,Sicily,Catania,AP
 NTA,,Natadola,-18.1025294,177.3180715,0,,Pacific/Fiji,NTA,FJ,,,,AP
 NTB,ENNO,Notodden Airport,59.583332,9.283333,744,http://www.notodden-flyplass.no/,Europe/Oslo,NTB,NO,Notodden,Telemark,Notodden,AP
@@ -5882,7 +5861,6 @@ NVA,SKNV,Benito Salas Airport,2.9517519500000002,-75.29355179494848,1473,,Americ
 NVD,,Nevada,37.85139,-94.30389,856,,America/Chicago,NVD,US,Nevada,Missouri,Vernon County,AP
 NVG,MNNG,Nueva Guinea,11.666667,-84.45,728,,America/Managua,NVG,NI,Nueva Guinea,Atlantico Sur,,AP
 NVI,UTSA,Navoi Airport,40.115,65.159164,1099,,Asia/Samarkand,NVI,UZ,Konimex,Navoiy,,AP
-NVK,,Framnes,68.425,17.425,0,,Europe/Oslo,NVK,NO,Narvik,Nordland,Narvik,AP
 NVM,,Brigadeiro Eduardo Gomes Airport,-13.81380253609,-56.0349239329,1404,,America/Cuiaba,NVM,BR,Nova Mutum,Mato Grosso,,AP
 NVN,KO02,Nervino,39.8184,-120.3537,4858,,America/Los_Angeles,NVN,US,Portola,California,Plumas County,AP
 NVP,SWNA,Novo Aripuana,-5.117820549999999,-60.36429342007336,121,,America/Manaus,NVP,BR,Novo Aripuana,Amazonas,Novo Aripuana,AP
@@ -5893,11 +5871,7 @@ NVY,VONV,Neyveli,11.6,79.433334,249,,Asia/Kolkata,NVY,IN,Vriddhachalam,Tamil Nad
 NWA,FMCI,Moheli,-12.2981305,43.76644801260554,45,,Indian/Comoro,NWA,KM,Djoyezi,Moheli,,AP
 NWH,,Parlin Field,43.385961949999995,-72.18568411099443,761,,America/New_York,NWH,US,Newport,New Hampshire,Sullivan County,AP
 NWI,EGSH,Norwich International Airport,52.6683484,1.2806942422978507,101,http://www.norwichairport.co.uk/,Europe/London,NWI,GB,Spixworth,England,Norfolk,AP
-NWP,,NS,47.3,-53.966667,0,,America/St_Johns,NWP,CA,Bay Roberts,Newfoundland and Labrador,,AP
-NWS,,Pier 11/Wall St. SPB,40.703056,-74.01056,36,,America/New_York,NYC,US,,,,AP
 NWT,,Nowata,-9.98549835,149.72788924937038,2057,,Pacific/Port_Moresby,NWT,PG,,,,AP
-NWU,,Bermuda NAS,32.75,-65.0,0,,Atlantic/Bermuda,BDA,BM,Saint George,Saint George,,AP
-NXX,,Willow Grove NAS,40.2,-75.13333,347,,America/New_York,NXX,US,Horsham,Pennsylvania,Montgomery County,AP
 NYA,USHN,Nyagan Airport,62.11053750000001,65.61141073357436,314,,Asia/Yekaterinburg,NYA,RU,Nyagan,Khanty-Mansiyskiy Avtonomnyy Okrug,,AP
 NYE,HKNI,Nyeri,-0.416667,36.95,5741,,Africa/Nairobi,NYE,KE,Nyeri,Nyeri,,AP
 NYG,,Quantico NAS,38.516666,-77.28333,0,,America/New_York,NYG,US,Quantico Station,Virginia,Prince William County,AP
@@ -5917,7 +5891,6 @@ NZE,GUNZ,Nzerekore,7.8155778,-8.7038786,1594,,Africa/Conakry,NZE,GN,Nzerekore,Nz
 NZG,UIUN,Nizhneangarsk Airport,55.801667,109.586667,1545,,Asia/Irkutsk,NZG,RU,,,,AP
 NZH,ZBMZ,Manzhouli Airport,49.567472499999994,117.3271129010715,2168,,Asia/Shanghai,NZH,CN,Zabaykal'sk,Transbaikal Territory,,AP
 NZL,ZBZL,Zhalantun Chengjisihan Airport,47.865833,122.7675,859,,Asia/Shanghai,NZL,CN,Qinggis Han,Inner Mongolia,,AP
-NZW,,South Weymouth,42.166668,-70.933334,150,,America/New_York,NZW,US,Rockland,Massachusetts,Plymouth County,AP
 NZY,KNZY,North Island NAS,32.7,-117.2,26,,America/Los_Angeles,SAN,US,Coronado,California,San Diego County,AP
 OAA,OASH,Shank Air Base,33.9232357,69.07781253482375,6722,,Asia/Kabul,OAA,AF,Pul-e `Alam,Lowgar,,AP
 OAG,YORG,Orange Airport,-33.3816,149.12447,3106,,Australia/Sydney,OAG,AU,Millthorpe,New South Wales,Blayney,AP
@@ -5938,22 +5911,18 @@ OBD,WABR,Obano,-3.91048535,136.23059311149825,5790,,Asia/Jayapura,OBD,ID,Obano,P
 OBE,KOBE,County,27.25,-80.833336,32,,America/New_York,OBE,US,Okeechobee,Florida,Okeechobee County,AP
 OBF,EDMO,Oberpfaffenhofen,48.0835074,11.288999243382674,1929,http://www.edmo-airport.de,Europe/Berlin,OBF,DE,Gilching,Bavaria,Upper Bavaria,AP
 OBI,SNTI,Obidos,-1.916667,-55.516666,95,,America/Santarem,OBI,BR,,,,AP
-OBK,,Sky Harbor,42.11667,-87.816666,675,,America/Chicago,OBK,US,Northbrook,Illinois,Cook County,AP
 OBL,,Zoersel,51.2645037,4.75290329580533,62,,Europe/Brussels,OBL,BE,Zoersel,Flanders,Provincie Antwerpen,AP
 OBM,AYMB,Morobe,-7.75,147.6,0,,Pacific/Port_Moresby,OBM,PG,,,,AP
 OBN,EGEO,Oban Airport,56.46333455,-5.400648379892633,62,,Europe/London,OBN,GB,Oban,Scotland,Argyll and Bute,AP
 OBO,RJCB,Tokachi-Obihiro Airport,42.73232595,143.2127336925417,459,,Asia/Tokyo,OBO,JP,Obihiro,Hokkaido,,AP
 OBS,LFHO,Vals-Lanas,44.666668,4.7,751,,Europe/Paris,OBS,FR,Chomerac,Rhone-Alpes,Departement de l'Ardeche,AP
-OBT,,Oakland/Coliseum Stat,39.4,-79.416664,2450,,America/New_York,OBT,US,,,,AP
 OBU,PAOB,Kobuk/Wien Airport,66.910468,-156.8861424,101,,America/Anchorage,OBU,US,,,,AP
 OBX,AYOB,Obo,-7.5830002,141.3170013,45,,Pacific/Port_Moresby,OBX,PG,Muting,Papua,,AP
-OBY,,Ittoqqortoormiit,70.583336,-21.666668,0,,America/Scoresbysund,OBY,GL,,,,AP
 OCA,07FA,Ocean Reef,25.325277,-80.27472,29,https://www.oceanreef.com/community/private-airport-1345.html,America/New_York,OCA,US,North Key Largo,Florida,Monroe County,AP
 OCC,SECO,Coca Airport,-0.4567311,-76.99002032360985,774,,America/Guayaquil,OCC,EC,Puerto Francisco de Orellana,Orellana,,AP
 OCE,KOXB,Municipal,38.316666,-75.11667,39,http://oceancitymd.gov/oc/departments/public-works/airport/,America/New_York,OCE,US,West Ocean City,Maryland,Worcester County,AP
 OCF,KOCF,Taylor Field,29.175556,-82.226944,72,http://www.ocalafl.org/airport/,America/New_York,OCF,US,Ocala,Florida,Marion County,AP
 OCH,KOCH,A L Mangham Jr. Regional,31.576551000000002,-94.70800648028734,288,http://www.ci.nacogdoches.tx.us/index.aspx?nid=634,America/Chicago,OCH,US,Nacogdoches,Texas,Nacogdoches County,AP
-OCI,,Oceanic,60.25,-147.86667,1233,,America/Anchorage,OCI,US,,,,AP
 OCJ,MKBS,Boscobel,18.400557,-76.96972,173,http://www.aaj.com.jm/ourairports/index.php#boscobel,America/Jamaica,OCJ,JM,Oracabessa,Saint Mary,,AP
 OCM,YBGD,Boolgeeda,-22.540644,117.27020102828958,1817,,Australia/Perth,OCM,AU,,,,AP
 OCN,KOKB,Municipal,33.218613,-117.35333,36,http://www.oceansidemunicipalairport.com/,America/Los_Angeles,OCN,US,Camp Pendleton South,California,San Diego County,AP
@@ -5976,7 +5945,6 @@ ODS,UKOO,Odessa International Airport,46.42729675,30.671640336265803,164,http://
 ODT,KODO,Odessa-Schlemeyer Field,31.921389,-102.386944,3004,,America/Phoenix,ODT,US,Odessa,Texas,,AP
 ODW,KOKH,Oak Harbor,48.25139,-122.68611,95,,America/Los_Angeles,ODW,US,Coupeville,Washington,Island County,AP
 ODY,VLOS,Oudomxay Airport,20.583332,104.166664,3822,,Asia/Vientiane,ODY,LA,Viangxai,Houaphan,,AP
-OEA,,Oneal,38.683334,-87.53333,416,,America/Indiana/Vincennes,OEA,US,Vincennes,Indiana,Knox County,AP
 OEC,WPOC,Ocussi,-9.205,124.34167,26,,Asia/Dili,OEC,TL,Pante Makasar,Oecusse,,AP
 OEL,UUOR,Orel,52.983334,36.1,567,,Europe/Moscow,OEL,RU,Orel,Orjol,,AP
 OEM,SMPA,Vincent Fayks,3.3444506,-55.446192118676834,511,,America/Paramaribo,OEM,SR,,,,AP
@@ -6005,7 +5973,6 @@ OGX,DAUU,Ain Beida Airport,31.9171828,5.411965642045519,429,,Africa/Algiers,OGX,
 OGZ,URMO,Vladikavkaz Airport,43.204641550000005,44.60982202193371,1646,,Europe/Moscow,OGZ,RU,Dalakovo,Ingushetiya,,AP
 OHA,NZOH,Royal Air Force Base,-40.208332,175.38667,111,http://www.airforce.mil.nz/about/hqbases/boh.htm,Pacific/Auckland,OHA,NZ,Bulls,Manawatu-Wanganui,Rangitikei District,AP
 OHB,FMFE,Ambohibary,-18.915993,48.220969,2962,,Indian/Antananarivo,OHB,MG,Moramanga,Alaotra Mangoro,,AP
-OHC,,AFS,63.32639,-168.96889,39,,America/Anchorage,OHC,US,,,,AP
 OHD,LWOH,Ohrid Airport,41.17937425,20.742970126092665,2270,http://ohd.airports.com.mk/,Europe/Skopje,OHD,MK,Misleshevo,,,AP
 OHE,ZYMH,Mohe Airport,52.9156841,122.42525985187558,1804,,Asia/Shanghai,OHE,CN,Xilinji,Heilongjiang Sheng,,AP
 OHH,UHSH,Novostroyka Airport,53.51637295,142.87331907232237,95,,Asia/Srednekolymsk,OHH,RU,Okha,Sakhalin,,AP
@@ -6016,7 +5983,6 @@ OHS,OOSH,Sohar Airport,24.38766535,56.62139832848415,104,,Asia/Muscat,MCT,OM,Al 
 OHT,OPKT,Kohat,33.583332,71.433334,1686,,Asia/Karachi,OHT,PK,Kohat,Khyber Pakhtunkhwa,,AP
 OIA,SDOW,Ourilandia,-6.76392515,-51.047096751155294,856,,America/Belem,OIA,BR,,,,AP
 OIC,KOIC,Eaton,42.533333,-75.53333,1013,http://www.co.chenango.ny.us/airport/,America/New_York,OIC,US,Norwich,New York,Chenango County,AP
-OIL,,Splane Memorial,41.433334,-79.7,1194,,America/New_York,OIL,US,Oil City,Pennsylvania,Venango County,AP
 OIM,RJTO,Oshima,34.7827315,139.3606535,124,,Asia/Tokyo,OIM,JP,Ito,Shizuoka,,AP
 OIR,RJEO,Okushiri Airport,42.166668,139.51666,0,,Asia/Tokyo,OIR,JP,Kamiiso,Hokkaido,,AP
 OIT,RJFO,Oita Airport,33.48025315,131.73595976930255,39,,Asia/Tokyo,OIT,JP,Kitsuki,Oita,,AP
@@ -6098,7 +6064,6 @@ ONJ,RJSR,Odate Noshiro Airport,40.19334325,140.36714159890715,242,,Asia/Tokyo,ON
 ONK,UERO,Olenyok Airport,68.51536114999999,112.47915289262505,643,,Asia/Yakutsk,ONK,RU,Olenyok,Sakha,,AP
 ONL,KONL,Municipal,42.45,-98.65,1952,,America/Chicago,ONL,US,O'Neill,Nebraska,Holt County,AP
 ONM,,Socorro,34.066666,-106.9,4593,,America/Denver,ONM,US,Socorro,New Mexico,Socorro County,AP
-ONN,,Onion Bay,58.233334,-152.83333,1817,,America/Anchorage,ONN,US,,,,AP
 ONO,KONO,Ontario Municipal Airport,44.0178894,-117.01040499429439,2188,,America/Boise,ONO,US,Ontario,Oregon,Malheur County,AP
 ONP,KONP,Newport,44.63333,-124.05,118,,America/Los_Angeles,ONP,US,Newport,Oregon,Lincoln County,AP
 ONQ,LTAS,Zonguldak,41.5086358,32.08897133952877,55,,Europe/Istanbul,ONQ,TR,Saltukova,Zonguldak,,AP
@@ -6141,7 +6106,6 @@ ORM,EGBK,Northampton,52.233334,-0.9,196,http://www.sywellaerodrome.co.uk/,Europe
 ORN,DAOO,Es Senia Airport,35.6206678,-0.6154202368508483,278,,Africa/Algiers,ORN,DZ,,,,AP
 ORO,MHYR,Yoro,15.125278,-87.13389,2158,,America/Tegucigalpa,ORO,HN,Yoro,Yoro,,AP
 ORP,FBOR,Orapa,-21.0,24.5,2975,,Africa/Gaborone,ORP,BW,Rakops,Central,,AP
-ORQ,,Heliport,41.11667,-73.36667,68,,America/New_York,ORQ,US,Westport,Connecticut,Fairfield County,AP
 ORR,YYOR,Yorketown,-35.002820299999996,137.6192858035999,206,,Australia/Adelaide,ORR,AU,,,,AP
 ORS,,Waterport,-18.633333,146.48334,0,,Australia/Brisbane,ORS,AU,,,,AP
 ORT,PAOR,Northway,62.961308,-141.9310183218222,1673,,America/Anchorage,ORT,US,,,,AP
@@ -6238,15 +6202,12 @@ OYL,HKMY,Moyale,3.533333,39.05,3517,,Africa/Nairobi,OYL,KE,Moyale,Marsabit,,AP
 OYN,YOUY,Ouyen,-35.0892885,142.3486862,154,,Australia/Melbourne,OYN,AU,,,,AP
 OYO,SAZH,Tres Arroyos,-38.36667,-60.25,321,,America/Argentina/Buenos_Aires,OYO,AR,Tres Arroyos,Buenos Aires,Partido de Tres Arroyos,AP
 OYP,SOOG,St-Georges de lOyapock,3.9,-51.8,19,,America/Cayenne,OYP,GF,Saint-Georges-de-l'Oyapock,Guyane,Guyane,AP
-OYS,,Yosemite Ntl Park,37.85,-119.55,9222,,America/Los_Angeles,OYS,US,Yosemite Valley,California,Mariposa County,AP
 OZA,KOZA,Ozona Municipalcipal,30.716667,-101.21667,2391,http://www.ozona.com/articles/view/ozona-municipal-airport-52b1db2c-3ff8-4122-8b3f-1a349bf0d2c8,America/Chicago,OZA,US,Ozona,Texas,Crockett County,AP
 OZC,RPMO,Labo Airport,8.17931945,123.84191227879472,134,,Asia/Manila,OZC,PH,Lapase,Northern Mindanao,Province of Misamis Occidental,AP
 OZG,GMAZ,Zagora Airport,30.266018850000002,-5.859202534443837,2381,,Africa/Casablanca,OZG,MA,Zagora,Souss-Massa-Draa,Zagora,AP
 OZH,UKDE,Zaporozhye Airport,47.869395850000004,35.31153502036521,321,,Europe/Zaporozhye,OZH,UA,Zaporizhzhya,Zaporizhia,,AP
-OZI,,Bobadilla,37.6625,-24.9,0,,Europe/Madrid,OZI,ES,Furnas,Azores,Povoacao,AP
 OZP,LEMO,Moron,37.24917,-5.759444,177,,Europe/Madrid,OZP,ES,Utrera,Andalusia,Provincia de Sevilla,AP
 OZR,KOZR,Cairns AAF,31.45,-85.666664,400,,America/Chicago,OZR,US,Ozark,Alabama,Dale County,AP
-OZU,,Montilla,37.6,-4.633333,1000,,Europe/Madrid,OZU,ES,Montilla,Andalusia,Province of Cordoba,AP
 OZZ,GMMZ,Ouarzazate Airport,30.938211250000002,-6.908943082878656,3710,,Africa/Casablanca,OZZ,MA,Ouarzazat,Souss-Massa-Draa,Ouarzazate,AP
 PAA,VYPA,Pa-an,16.892778,97.67833,75,,Asia/Rangoon,PAA,MM,Hpa-an,Kayin,,AP
 PAB,VEBU,Bilaspur,31.316668,76.833336,2588,,Asia/Kolkata,PAB,IN,Bilaspur,Himachal Pradesh,Bilaspur,AP
@@ -6282,7 +6243,6 @@ PBG,KPBG,Plattsburgh International Airport,44.6689275,-73.4719379,206,http://www
 PBH,VQPR,Paro Airport,27.403184449999998,89.42341649453166,7293,,Asia/Thimphu,PBH,BT,Paro,Paro,,AP
 PBI,KPBI,Palm Beach International Airport,26.6859478,-80.09248650717163,32,http://www.pbia.org,America/New_York,PBI,US,Haverhill,Florida,Palm Beach County,AP
 PBJ,NVSI,Paama,-16.432021900000002,168.23523696852922,45,,Pacific/Efate,PBJ,VU,,,,AP
-PBK,,Pack Creek,57.8,-134.7,170,,America/Anchorage,PBK,US,,,,AP
 PBL,SVPC,Puerto Cabello,10.4789026,-68.07287449307714,59,,America/Caracas,PBL,VE,Puerto Cabello,Carabobo,Municipio Puerto Cabello,AP
 PBM,SMJP,Zanderij International Airport,5.45209655,-55.18802501876111,52,http://www.japi-airport.com,America/Paramaribo,PBM,SR,Onverwacht,Para,,AP
 PBN,FNPA,Porto Amboim,-10.7218306,13.765036832632958,26,,Africa/Luanda,PBN,AO,Sumbe,Cuanza Sul,,AP
@@ -6290,24 +6250,18 @@ PBO,YPBO,Paraburdoo Airport,-23.17202315,117.74584925439711,1361,,Australia/Pert
 PBP,MRIA,Punta Islita,10.416667,-85.166664,68,,America/Costa_Rica,PBP,CR,Canas,Guanacaste,Canton de Canas,AP
 PBQ,SWPM,Pimenta Bueno,-11.7,-61.2,626,,America/Porto_Velho,PBQ,BR,Pimenta Bueno,Rondonia,Pimenta Bueno,AP
 PBR,MGPB,Puerto Barrios,15.73187325,-88.58476326578091,45,,America/Guatemala,PBR,GT,Puerto Barrios,Izabal,Municipio de Puerto Barrios,AP
-PBS,,Patong Beach,7.895278,98.291664,0,,Asia/Bangkok,PBS,TH,Patong,Phuket,,AP
 PBT,,Puerto Leda,-20.616667,-58.026943,262,,America/Asuncion,PBT,PY,Fuerte Olimpo,Alto Paraguay,,AP
 PBU,VYPT,Putao,27.3267245,97.42638917802654,1397,,Asia/Rangoon,PBU,MM,Zhowagoin,Tibet Autonomous Region,,AP
 PBV,SWPG,Porto Dos Gauchos,-11.5166667,-57.3333333,807,,America/Cuiaba,PBV,BR,,,,AP
-PBW,,Palibelo,9.53,-0.22,649,,Asia/Makassar,PBW,ID,Yendi,Northern,Yendi,AP
 PBX,SWPQ,Porto Alegre Do Norte,-10.8612428,-51.6844371,629,,America/Cuiaba,PBX,BR,,,,AP
-PBY,,Hamilton/Proserpine,-20.283333,148.83333,0,,Australia/Brisbane,PBY,AU,,,,AP
 PBZ,FAPG,Plettenberg Bay Airport,-34.08766745,23.326063451340605,426,,Africa/Johannesburg,PBZ,ZA,Plettenberg Bay,Western Cape,Eden District Municipality,AP
 PCA,PAOC,Portage Creek,58.9058958,-157.715863,95,,America/Anchorage,PCA,US,,,,AP
 PCB,WIHP,Pondok Cabe,-6.3364522,106.76341868042863,187,,Asia/Jakarta,PCB,ID,Pamulang,West Java,,AP
 PCC,,Puerto Rico,1.9,-75.15,793,,America/Bogota,PCC,CO,,,,AP
 PCD,KPDC,Prairie du Chien Municipal Airport,43.01881145,-91.1171306535747,652,,America/Chicago,PCD,US,Prairie du Chien,Wisconsin,Crawford County,AP
-PCE,,Painter Creek,57.164165,-157.43306,291,,America/Anchorage,PCE,US,,,,AP
 PCF,FAPS,Potchefstroom,-26.6704577,27.083901971724167,4458,,Africa/Johannesburg,PCF,ZA,Potchefstroom,North-West,Dr Kenneth Kaunda District Municipality,AP
-PCG,,Paso Caballos,17.26,-90.24722,167,,America/Guatemala,PCG,GT,San Andres,Peten,Municipio de San Andres,AP
 PCH,MHPC,Palacios,15.0,-89.0,1975,,America/Tegucigalpa,PCH,HN,Buenos Aires,Copan,,AP
 PCJ,SGLV,Puerto La Victoria,-22.268888,-57.92861,252,,America/Asuncion,PCJ,PY,,,,AP
-PCK,,Porcupine Creek,67.2385084,-150.2894811,1095,,America/Anchorage,PCK,US,,,,AP
 PCL,SPCL,Capitan Rolden Airport,-8.333333,-74.63333,551,,America/Lima,PCL,PE,Puerto Callao,Ucayali,Provincia de Coronel Portillo,AP
 PCM,,Playa Del Carmen,20.6,-87.1,59,,America/Cancun,PCM,MX,Playa del Carmen,Quintana Roo,,AP
 PCN,NZPN,Picton Aerodrome,-41.35,174.03334,2496,,Pacific/Auckland,PCN,NZ,Picton,Marlborough,Marlborough District,AP
@@ -6367,10 +6321,8 @@ PEZ,UWPP,Penza Airport,53.110733999999994,45.02345501356966,580,,Europe/Moscow,P
 PFA,,Paf Warren,58.666668,-156.83333,65,,America/Anchorage,PFA,US,,,,AP
 PFB,SBPF,Passo Fundo Airport,-28.2435244,-52.32669864043906,2362,,America/Sao_Paulo,PFB,BR,Passo Fundo,Rio Grande do Sul,Passo Fundo,AP
 PFC,KPFC,Pacific City State,45.198597250000006,-123.96171871467799,32,,America/Los_Angeles,PFC,US,Pacific City,Oregon,Tillamook County,AP
-PFD,,Port Frederick,57.95,-135.65,9,,America/Anchorage,PFD,US,,,,AP
 PFJ,BIPA,Patreksfjordur,65.03333,-19.008333,2322,,Atlantic/Reykjavik,PFJ,IS,,,,AP
 PFM,,Primrose Aerodrome,55.390556,-111.120278,2257,,America/Edmonton,PFM,CA,,,,AP
-PFN,,Bay County,30.207085,-85.68309,19,,America/Chicago,PFN,US,Pretty Bayou,Florida,Bay County,AP
 PFO,LCPH,Paphos International Airport,34.71791325,32.489094835033505,22,http://paphosinternationalairport.com/index_papxmas.html,Asia/Nicosia,PFO,CY,Paphos,Pafos,,AP
 PFQ,OITP,Parsabad,39.60367545,47.88360730015924,249,,Asia/Tehran,PFQ,IR,Parsabad,Ardabil,,AP
 PFR,FZVS,Ilebo,-4.330204500000001,20.58850987797728,1446,,Africa/Lubumbashi,PFR,CD,Ilebo,Kasai-Occidental,,AP
@@ -6380,7 +6332,6 @@ PGC,W99,Grant County,39.0,-79.11667,898,,America/New_York,PGC,US,Petersburg,West
 PGD,KPGD,Charlotte County Airport,26.919167,-81.99139,22,http://www.flypgd.com/,America/New_York,PGD,US,Cleveland,Florida,Charlotte County,AP
 PGE,,Yegepa,-7.134069050000001,146.1560903035904,4163,,Pacific/Port_Moresby,PGE,PG,,,,AP
 PGF,LFMP,Llabanere Airport,42.741016,2.868183,124,,Europe/Paris,PGF,FR,Peyrestortes,Languedoc-Roussillon,Departement des Pyrenees-Orientales,AP
-PGG,,Progresso,-6.954167,-55.46111,688,,America/Santarem,PGG,BR,Jacareacanga,Para,Jacareacanga,AP
 PGH,VIPT,Pantnagar Airport,29.0324015,79.47558715752675,728,,Asia/Kolkata,PGH,IN,Kichha,Uttarakhand,Udham Singh Nagar,AP
 PGI,FNCH,Chitato,-7.3588901,20.8047009,2454,,Africa/Luanda,PGI,AO,,,,AP
 PGK,WIPK,Depati Amir Airport,-2.16040755,106.1396720726779,65,,Asia/Jakarta,PGK,ID,Pangkalpinang,Bangka-Belitung Islands,,AP
@@ -6388,7 +6339,6 @@ PGL,KPQL,Jackson County,30.383333,-88.51667,49,http://www.co.jackson.ms.us/depar
 PGM,PGM,Port Graham,59.347423,-151.82866522036903,39,,America/Anchorage,PGM,US,,,,AP
 PGN,AYPG,Pangia,-6.3,144.2,4458,,Pacific/Port_Moresby,PGN,PG,Ialibu,Southern Highlands,,AP
 PGO,KPSO,Stevens Field,37.28460005,-107.05715539919868,7706,http://www.stevensfield.com/,America/Denver,PGO,US,Pagosa Springs,Colorado,Archuleta County,AP
-PGP,,Porto Alegre,0.033333,6.533333,72,,Africa/Sao_Tome,PGP,ST,,,,AP
 PGQ,WAEM,Buli Airport,0.9171716999999999,128.38098388661,19,,Asia/Jayapura,PGQ,ID,Buli,Maluku Utara,,AP
 PGR,KPGR,Paragould Kirk Field,36.061285,-90.5105521,282,http://cityofparagould.com/index.php?pageID=11287_2,America/Chicago,PGR,US,Paragould,Arkansas,Greene County,AP
 PGS,,Peach Springs,35.5430476,-113.4146572,4973,,America/Phoenix,PGS,US,Peach Springs,Arizona,Mohave County,AP
@@ -6405,7 +6355,6 @@ PHF,KPHF,Newport News/Williamsburg International Airport,37.132296499999995,-76.
 PHG,,Port Harcourt City,5.033333,6.833333,55,,Africa/Lagos,PHC,NG,Elele,Rivers,,AP
 PHH,,Phan Thiet,10.9,108.066666,229,,Asia/Ho_Chi_Minh,PHH,VN,Phan Thiet,Binh Thuan,,AP
 PHI,SNYE,Pinheiro,-2.516667,-45.083332,22,,America/Fortaleza,PHI,BR,Pinheiro,Maranhao,Pinheiro,AP
-PHJ,,Port Hunter,-32.916668,151.76666,22,,Australia/Sydney,NTL,AU,Carrington,New South Wales,Newcastle,AP
 PHK,KPHK,Palm Beach Co Glades,26.78591995,-80.69270838990238,36,http://www.pbia.org/about/general-aviation/glades-airport/,America/New_York,PHK,US,Pahokee,Florida,Palm Beach County,AP
 PHL,KPHL,Philadelphia International Airport,39.875018,-75.23521278969667,26,http://www.phl.org/,America/New_York,PHL,US,Colwyn,Pennsylvania,Delaware County,AP
 PHN,KPHN,St Clair County International,42.9109722,-82.5288611,659,,America/Detroit,PHN,US,Marysville,Michigan,Saint Clair County,AP
@@ -6419,16 +6368,12 @@ PHU,,Phu Vinh,9.95,106.333336,42,,Asia/Ho_Chi_Minh,PHU,VN,Tra Vinh,Tra Vinh,,AP
 PHW,FAPH,Phalaborwa Airport,-23.9364999,31.15517526212288,1423,,Africa/Johannesburg,PHW,ZA,Phalaborwa,Limpopo,Mopani District Municipality,AP
 PHX,KPHX,Phoenix Sky Harbor International Airport,33.43289075,-112.00942230268426,1112,http://phoenix.gov/skyharborairport/,America/Phoenix,PHX,US,Tempe Junction,Arizona,Maricopa County,AP
 PHY,VTPB,Phetchabun,16.6758588,101.1905078,419,,Asia/Bangkok,PHY,TH,Lom Sak,Phetchabun,,AP
-PHZ,,Phi Phi Island,8.166667,98.28333,0,,Asia/Bangkok,PHZ,TH,Thalang,Phuket,,AP
 PIA,KPIA,Peoria International Airport,40.677171349999995,-89.6989893705192,666,,America/Chicago,PIA,US,Bellevue,Illinois,Peoria County,AP
 PIB,KPIB,Hattiesburg-Laurel Regional Airport,31.4672,-89.3363366,223,,America/Chicago,LUL,US,Rawls Springs,Mississippi,Forrest County,AP
 PIC,MBPI,Pine Cay,21.87481975,-72.0916582724344,32,,America/Grand_Turk,PIC,TC,,,,AP
-PID,,Paradise Island,25.083332,-77.3,29,,America/Nassau,NAS,BS,,,,AP
 PIE,KPIE,St. Petersburg-Clearwater International Airport,27.90994325,-82.68769326031256,49,,America/New_York,TPA,US,South Highpoint,Florida,Pinellas County,AP
 PIF,RCSQ,Pingtung,22.705004,120.490234,62,,Asia/Taipei,PIF,TW,Pingtung,Taiwan,Pingtung,AP
-PIG,,Pitinga,-24.75,-51.716667,2808,,America/Boa_Vista,PIG,BR,Pitanga,Parana,Pitanga,AP
 PIH,KPIH,Pocatello Regional Airport,42.9074805,-112.5928392860736,4442,,America/Boise,PIH,US,Chubbuck,Idaho,Bannock County,AP
-PII,,Phillips Field,64.86389,-147.71388,459,,America/Anchorage,FAI,US,,,,AP
 PIK,EGPK,Glasgow Prestwick Airport,55.50230535,-4.577596602973978,49,http://www.glasgowprestwick.com/,Europe/London,GLA,GB,Prestwick,Scotland,South Ayrshire,AP
 PIL,SGPI,Pilar,-26.866667,-58.333332,144,,America/Asuncion,PIL,PY,Pilar,Neembucu,,AP
 PIM,KPIM,Garden Harris County,32.86667,-84.833336,908,http://harriscountyga.gov/departments/airport/,America/New_York,PIM,US,Pine Mountain,Georgia,Harris County,AP
@@ -6449,8 +6394,6 @@ PJB,KPAN,Payson,34.25658155,-111.33883155349753,5118,http://www.paysonaz.gov/Dep
 PJC,SGPJ,Pedro Juan Caballero,-22.5,-55.666668,2017,,America/Asuncion,PJC,PY,,,,AP
 PJG,OPPG,Panjgur,26.9553442,64.13388676391679,3264,,Asia/Karachi,PJG,PK,Panjgur,Balochistan,,AP
 PJM,MRPJ,Puerto Jimenez,8.583333,-83.333336,0,http://www.natureair.com/destinations/jimenez_costa_rica.html,America/Costa_Rica,PJM,CR,Golfito,Puntarenas,Canton de Golfito,AP
-PJS,,Port San Juan,60.04861,-148.06389,0,,America/Anchorage,PJS,US,,,,AP
-PJZ,,Puerto Juarez,21.166668,-86.833336,32,,America/Cancun,PJZ,MX,Cancun,Quintana Roo,,AP
 PKA,PAPK,Napaskiak Sea Plane Base,60.710835,-161.75806,0,,America/Anchorage,PKA,US,,,,AP
 PKB,KPKB,Wood County Airport,39.345554,-81.43889,912,,America/New_York,PKB,US,Reno,Ohio,Washington County,AP
 PKC,UHPP,Petropavlovsk-Kamchatsky Airport,53.016666,158.65,39,,Asia/Kamchatka,PKC,RU,Petropavlovsk-Kamchatsky,Kamtsjatka,,AP
@@ -6461,13 +6404,11 @@ PKG,WMPA,Pangkor Airport,4.216667,100.7,39,,Asia/Kuala_Lumpur,PKG,MY,,,,AP
 PKH,LGHL,Alexion,37.301388,23.147223,42,,Europe/Athens,PKH,GR,Porto Cheli,Peloponnese,Nomos Argolidos,AP
 PKJ,MGPG,Playa Grande,15.6425,-90.76195,2769,,America/Guatemala,PKJ,GT,Chicaman,Quiche,,AP
 PKK,VYPU,Pakokku,21.343332,95.10639,216,,Asia/Rangoon,PKK,MM,Pakokku,Magway,,AP
-PKL,,Pakatoa Island,-37.806946,174.85333,36,,Pacific/Auckland,PKL,NZ,,,,AP
 PKM,,Port Kaituma,7.7439968,-59.8793252,19,,America/Guyana,PKM,GY,,,,AP
 PKN,WAGI,Iskandar Airport,-2.7057634,111.67340824897687,36,,Asia/Pontianak,PKN,ID,Pangkalanbuun,Central Kalimantan,,AP
 PKO,DBBP,Parakou,9.3576899,2.6096799,1269,,Africa/Porto-Novo,PKO,BJ,Parakou,Borgou,,AP
 PKP,NTGP,Puka Puka,-14.75,-138.96666,0,,Pacific/Tahiti,PKP,PF,,,,AP
 PKR,VNPK,Pokhara Airport,28.2006145,83.98219244397883,2677,,Asia/Kathmandu,PKR,NP,Pokhara,Western Region,Gandaki Zone,AP
-PKS,,Paksane,18.366667,103.683334,518,,Asia/Vientiane,PKS,LA,Muang Pakxan,Bolikhamxai,,AP
 PKT,YPKT,Port Keats,-14.251098899999999,129.53016901828997,104,,Australia/Darwin,PKT,AU,,,,AP
 PKU,WIBB,Sultan Syarif Kasim II International Airport,0.45756595,101.440153194186,170,,Asia/Jakarta,PKU,ID,,,,AP
 PKV,ULOO,Pskov Airport,57.816666,28.3,141,,Europe/Moscow,PKV,RU,Pskov,Pskov,,AP
@@ -6503,14 +6444,12 @@ PMA,HTPE,Wawi Airport,-5.242222,39.801945,98,,Africa/Dar_es_Salaam,PMA,TZ,Chake 
 PMB,KPMB,Intermediate,49.0,-98.083336,1299,,America/Chicago,PMB,US,Morden,Manitoba,,AP
 PMC,SCTE,El Tepual Airport,-41.443561700000004,-73.09450467694802,305,,America/Santiago,PMC,CL,Puerto Montt,Los Lagos,Provincia de Llanquihue,AP
 PMD,KPMD,La Palmdale Regional Airport,34.6275,-118.083336,2500,,America/Los_Angeles,PMD,US,Palmdale,California,Los Angeles County,AP
-PME,,Portsmouth,50.8,-1.083333,49,,Europe/London,PME,GB,Portsmouth,England,Portsmouth,AP
 PMF,LIMP,Parma Airport,44.82609055,10.296814771033567,88,,Europe/Rome,MIL,IT,Parma,Emilia-Romagna,Provincia di Parma,AP
 PMG,SBPP,International,-22.55,-55.7,2119,,America/Campo_Grande,PMG,BR,Ponta Pora,Mato Grosso do Sul,Ponta Pora,AP
 PMH,KPMH,Greater Portsmouth Regional,38.75,-82.98333,620,http://www.sciotocountyohio.com/airports.html,America/New_York,PMH,US,Portsmouth,Ohio,Scioto County,AP
 PMI,LEPA,Palma de Mallorca Airport,39.553224549999996,2.729030991511172,19,http://www.aena.es/csee/Satellite?cid=1046276292735&pagename=subHome&Language=EN_GB&SiteName=PMI&c=Page,Europe/Madrid,PMI,ES,s'Arenal,Balearic Islands,Illes Balears,AP
 PMK,YPAM,Palm Island Airport,-18.333332,146.66667,0,,Australia/Brisbane,PMK,AU,Ingham,Queensland,Hinchinbrook,AP
 PML,PAAL,AFS,56.005554,-160.55833,22,,America/Anchorage,PML,US,,,,AP
-PMM,,Phanom Sarakham,13.75,101.35,22,,Asia/Bangkok,PMM,TH,Phanom Sarakham,Chachoengsao,,AP
 PMN,AYPQ,Pumani,-9.716667,149.4,1325,,Pacific/Port_Moresby,PMN,PG,,,,AP
 PMO,LICJ,Falcone-Borsellino Airport,38.186523,13.104779,39,http://www.gesap.it/index.php,Europe/Rome,PMO,IT,Cinisi,Sicily,Palermo,AP
 PMP,AYPJ,Pimaga,-6.666667,143.41667,1833,,Pacific/Port_Moresby,PMP,PG,Mendi,Southern Highlands,,AP
@@ -6518,7 +6457,6 @@ PMQ,SAWP,Perito Moreno,-46.541759150000004,-70.97131502202217,1414,,America/Arge
 PMR,NZPM,Palmerston North Airport,-40.32289885,175.61964008329613,95,http://www.pnairport.co.nz/index.php,Pacific/Auckland,PMR,NZ,Palmerston North,Manawatu-Wanganui,Palmerston North City,AP
 PMS,OSPR,Palmyra,34.6,38.25,1909,,Asia/Damascus,PMS,SY,Tadmur,Homs,,AP
 PMT,SYPM,Paramakotoi,7.566667,-57.183334,2600,,America/Guyana,PMT,GY,Mahaica Village,Demerara-Mahaica,,AP
-PMU,,SPB,61.983334,-160.33333,226,,America/Anchorage,PMU,US,,,,AP
 PMV,SVMG,Santiago Marino International Airport,10.917189,-63.96899,68,,America/Caracas,PMV,VE,San Juan Bautista,Nueva Esparta,Municipio Diaz,AP
 PMW,SBPJ,Palmas Airport,-10.241667,-48.35278,757,,America/Araguaina,PMW,BR,,,,AP
 PMX,13MA,Metropolitan,42.15,-72.316666,377,,America/New_York,PMX,US,Palmer,Massachusetts,Hampden County,AP
@@ -6529,7 +6467,6 @@ PNB,SDPE,Porto Nacional,-10.71799955,-48.39911065205263,810,,America/Araguaina,P
 PNC,KPNC,Ponca City,36.7314036,-97.09903145822298,987,http://www.poncacityok.gov/index.aspx?nid=181,America/Chicago,PNC,US,Ponca City,Oklahoma,Kay County,AP
 PND,,Punta Gorda,16.1,-88.816666,32,,America/Belize,PND,BZ,Punta Gorda,Toledo,,AP
 PNE,KPNE,North Philadelphia,40.080276,-75.0125,88,http://www.phl.org/pne/pne.html,America/New_York,PHL,US,Cornwells Heights,Pennsylvania,Bucks County,AP
-PNF,,Peterson's Point,58.683334,-156.83333,104,,America/Anchorage,PNF,US,,,,AP
 PNG,SSPG,Paranagua,-25.53969285,-48.53062440956646,32,,America/Sao_Paulo,PNG,BR,Paranagua,Parana,Paranagua,AP
 PNH,VDPP,Phnom Penh International Airport,11.5470571,104.84811156075017,39,http://www.cambodia-airports.com/phnompenh/en/,Asia/Phnom_Penh,PNH,KH,Phnom Penh,Phnom Penh,,AP
 PNI,PTPN,Pohnpei Airport,6.9836798,158.20381948562675,59,,Pacific/Pohnpei,PNI,FM,Kolonia Town,Pohnpei,Kolonia Municipality,AP
@@ -6537,7 +6474,6 @@ PNJ,,Peng Lai/Sha He Kou,37.808887,120.812775,19,,Asia/Shanghai,PNJ,CN,Nanwang,S
 PNK,WIOO,Supadio International Airport,-0.14735,109.40533,49,,Asia/Pontianak,PNK,ID,Pontianak,West Kalimantan,,AP
 PNL,LICG,Pantelleria Airport,36.813767999999996,11.962350735013088,567,,Europe/Rome,PNL,IT,Pantelleria,Sicily,Trapani,AP
 PNN,KPNN,Princeton,45.233334,-67.566666,154,,America/New_York,PNN,US,Calais,Maine,Washington County,AP
-PNO,,Pinotepa Nacional,16.3500004,-98.0619965,692,,America/Mexico_City,PNO,MX,Santiago Pinotepa Nacional,Oaxaca,,AP
 PNP,AYGR,Girua Airport,-8.80380505,148.31082121223585,265,,Pacific/Port_Moresby,PNP,PG,,,,AP
 PNQ,VAPO,Pune Airport,18.58033,73.91838555259571,1912,,Asia/Kolkata,PNQ,IN,Lohogaon,Maharashtra,Pune Division,AP
 PNR,FCPP,Pointe Noire Airport,-4.81575645,11.886634070093734,95,,Africa/Brazzaville,PNR,CG,Pointe-Noire,Pointe-Noire,,AP
@@ -6563,7 +6499,6 @@ POM,AYPY,Jacksons International Airport,-9.4402674,147.21712862095984,88,,Pacifi
 PON,MGPP,Poptun,16.32617325,-89.4137530262015,1683,,America/Guatemala,PON,GT,Poptun,Peten,,AP
 POO,SBPC,Pocos De Caldas,-21.842504849999997,-46.566647194940074,4110,,America/Sao_Paulo,POO,BR,Pocos de Caldas,Minas Gerais,Pocos De Caldas,AP
 POP,MDPP,La Union Airport,19.754942,-70.56315,59,,America/Santo_Domingo,POP,DO,Puerto Plata,Puerto Plata,Puerto Plata,AP
-POQ,,Polk Inlet,55.35,-132.5,111,,America/Anchorage,POQ,US,,,,AP
 POR,EFPO,Pori Airport,61.469192,21.7909161,29,http://www.finavia.fi/en/pori/,Europe/Helsinki,POR,FI,Pori,Satakunta,Pori,AP
 POS,TTPP,Piarco International Airport,10.59734525,-61.339509684592386,49,,America/Port_of_Spain,POS,TT,Arouca,Tunapuna/Piarco,,AP
 POT,MKKJ,Ken Jones,18.198334,-76.53555,32,,America/Jamaica,POT,JM,Hope Bay,Portland,,AP
@@ -6576,7 +6511,6 @@ POZ,EPPO,Poznan Airport,52.42056395,16.8317916444456,249,http://www.airport-pozn
 PPA,KPPA,Perry Lefors Field,35.533333,-100.96667,3244,,America/Chicago,PPA,US,Pampa,Texas,Gray County,AP
 PPB,SBDN,A. De Barros Airport,-22.1,-51.45,1332,http://www.daesp.sp.gov.br/aeroporto-detalhe/?id=879,America/Sao_Paulo,PPB,BR,Alvares Machado,Sao Paulo,Alvares Machado,AP
 PPC,PAPR,Prospect Creek,66.81395885,-150.64384646872813,1069,,America/Anchorage,PPC,US,,,,AP
-PPD,,Palmas Del Mar,18.15,-65.833336,78,,America/Puerto_Rico,HUC,PR,Humacao,Humacao,,AP
 PPE,MMPE,Puerto Penasco,31.383333,-113.5,65,,America/Hermosillo,PPE,MX,Puerto Penasco,Sonora,Puerto Penasco,AP
 PPF,KPPF,Tri-City,37.3323519,-95.508499,875,http://www.parsonsks.com/index.aspx?NID=249,America/Chicago,PPF,US,Cherryvale,Kansas,Montgomery County,AP
 PPG,NSTU,Pago Pago International Airport,-14.3347658,-170.71596862723766,52,,Pacific/Pago_Pago,PPG,AS,Tafuna,Western District,,AP
@@ -6587,7 +6521,6 @@ PPK,UACP,Petropavlovsk Airport,54.774539950000005,69.18321518318967,452,,Asia/Al
 PPL,VNPL,Phaplu,27.518013449999998,86.58514934531868,8149,,Asia/Kathmandu,PPL,NP,,,,AP
 PPM,KPMP,Pompano Beach,26.25,-80.11667,32,http://pompanobeachfl.gov/index.php/pages/pw_airpark/airpark,America/New_York,PPM,US,Kendall Green,Florida,Broward County,AP
 PPN,SKPP,Guillermo Leon Valencia Airport,2.4547051,-76.60875093700525,5682,,America/Bogota,PPN,CO,Popayan,Cauca,,AP
-PPO,,Powell Point,24.9,-76.35,0,,America/Nassau,PPO,BS,,,,AP
 PPP,YBPN,Whitsunday Coast Airport,-20.4923508,148.55346993636186,55,,Australia/Brisbane,PPP,AU,,,,AP
 PPQ,NZPP,Paraparaumu Airport,-40.904610000000005,174.9862494817145,22,,Pacific/Auckland,PPQ,NZ,Paraparaumu,Wellington,Kapiti Coast District,AP
 PPR,WIDE,Pasir Pangarayan,0.833333,100.36667,190,,Asia/Jakarta,PPR,ID,Pasirpengarayan,Riau,,AP
@@ -6605,19 +6538,15 @@ PQI,KPQI,Presque Isle Municipal Airport,46.685,-68.0475,459,,America/New_York,PQ
 PQM,MMPQ,Palenque,17.53322045,-92.01424161757578,173,,America/Mexico_City,PQM,MX,Palenque,Chiapas,,AP
 PQQ,YPMQ,Port Macquarie Airport,-31.4357662,152.87350282041024,26,http://www.hastings.nsw.gov.au/www/html/455-welcome-to-port-macquarie-airport.asp?intLocationID=455,Australia/Sydney,PQQ,AU,,,,AP
 PQS,,Pilot Station Airport,61.9348255,-162.900546,91,,America/Anchorage,PQS,US,,,,AP
-PQT,,Qeqertaq Heliport,69.9994,-51.3037,42,,America/Godthab,PQT,GL,,,,AP
 PRA,SAAP,General Justo Jose de Urquiza Airport,-31.7975709,-60.4829340773004,242,,America/Argentina/Cordoba,PRA,AR,San Benito,Entre Rios,,AP
 PRB,KPRB,Paso Robles,35.6756407,-120.63062553873178,741,http://www.prcity.com/government/departments/publicworks/airport/,America/Los_Angeles,PRB,US,Paso Robles,California,San Luis Obispo County,AP
 PRC,KPRC,Prescott Airport,34.65,-112.424164,5022,,America/Phoenix,PRC,US,Chino Valley,Arizona,Yavapai County,AP
 PRD,YPDO,Pardoo,-20.1,119.11667,26,,Australia/Perth,PRD,AU,,,,AP
 PRE,,Pore,5.733333,-71.983333,902,,America/Bogota,PRE,CO,,,,AP
-PRF,,Port Johnson,55.13333,-132.0,0,,America/Anchorage,PRF,US,,,,AP
 PRG,LKPR,Vaclav Havel Airport Prague,50.1020451,14.27056489323675,1181,http://www.prg.aero,Europe/Prague,PRG,CZ,Hostivice,Central Bohemia,,AP
 PRH,VTCP,Phrae Airport,18.13174175,100.16354112141005,515,,Asia/Bangkok,PRH,TH,Phrae,Phrae,,AP
 PRI,FSPP,Praslin Island Airport,-4.3186006500000005,55.691294938853574,55,,Indian/Mahe,PRI,SC,Victoria,English River,,AP
-PRJ,,Capri,40.55,14.233333,652,,Europe/Rome,PRJ,IT,Capri,Campania,Provincia di Napoli,AP
 PRK,FAPK,Prieska,-29.666668,22.7,3238,,Africa/Johannesburg,PRK,ZA,Prieska,Northern Cape,Pixley ka Seme District Municipality,AP
-PRL,,Port Oceanic,60.208332,-147.81944,0,,America/Anchorage,PRL,US,Girdwood,Alaska,Anchorage Municipality,AP
 PRM,LPPM,Portimao Airport,37.13333,-8.533333,0,,Europe/Lisbon,PRM,PT,Portimao,Faro,Portimao,AP
 PRN,BKPR,Pristina International Airport,42.57643955,21.032371075473243,1758,http://www.airportpristina.com/,Europe/Belgrade,PRN,XK,Glanica,Pristina,Komuna e Gracanices,AP
 PRO,KPRO,Perry Municipal,41.85,-94.1,1003,http://www.perryia.org/perry-municipal-airport.html,America/Chicago,PRO,US,Perry,Iowa,Dallas County,AP
@@ -6625,7 +6554,6 @@ PRP,LFKO,Propriano,41.660028,8.89373649895094,19,,Europe/Paris,PRP,FR,Propriano,
 PRQ,SARS,Pres. Roque Saenz Pena,-26.833332,-60.666668,321,,America/Argentina/Cordoba,PRQ,AR,Napenay,Chaco,,AP
 PRR,SYPR,Paruima,5.8159679,-61.0588321,1624,,America/Guyana,PRR,GY,,,,AP
 PRS,AGGP,Parasi,-8.166667,158.0,0,,Pacific/Guadalcanal,PRS,SB,,,,AP
-PRT,,Coast Guard Heliport,58.35,-134.55,22,,America/Anchorage,PRT,US,,,,AP
 PRU,VYPY,Prome,18.8256187,95.26752966607295,141,,Asia/Rangoon,PRU,MM,,,,AP
 PRV,LKPO,Prerov,49.59028,17.208332,780,,Europe/Prague,PRV,CZ,Hnevotin,Olomoucky,,AP
 PRW,,Prentice,45.5387512,-90.2800207,1561,http://vil.prentice.wi.gov/departments/airport/,America/Chicago,PRW,US,Phillips,Wisconsin,Price County,AP
@@ -6651,7 +6579,6 @@ PSP,KPSP,Palm Springs International Airport,33.83033915,-116.50964534531111,459,
 PSQ,9N2,SPB,39.868057,-75.24861,19,http://www.phillyseaplanebase.com/,America/New_York,PHL,US,Paulsboro,New Jersey,Gloucester County,AP
 PSR,LIBP,Abruzzo Airport,42.4321436,14.186080677809038,26,http://www.abruzzo-airport.it/eng/index.php,Europe/Rome,PSR,IT,Sambuceto,Abruzzo,Provincia di Chieti,AP
 PSS,SARP,Posadas Airport,-27.391727449999998,-55.966770332177454,436,,America/Argentina/Cordoba,PSS,AR,Posadas,Misiones,Departamento de Capital,AP
-PST,,Preston,20.75,-75.666664,0,,America/Havana,PST,CU,Banes,Holguin,,AP
 PSU,WIOP,Putussibau Airport,0.8355697,112.93713061532932,95,,Asia/Makassar,PSU,ID,Kapit,Sarawak,,AP
 PSV,EGSZ,Papa Stour,60.321701,-1.69306,32,,Europe/London,SDZ,GB,,,,AP
 PSW,SNOS,Passos,-20.716667,-46.61667,2427,,America/Sao_Paulo,PSW,BR,Passos,Minas Gerais,Passos,AP
@@ -6665,7 +6592,6 @@ PTD,PAAP,Port Alexander,56.25,-134.65,29,,America/Anchorage,PTD,US,,,,AP
 PTF,NFFO,Malololailai,-17.783333,177.21666,0,,Pacific/Fiji,PTF,FJ,,,,AP
 PTG,FAPP,Polokwane Airport,-23.916668,29.966667,4872,,Africa/Johannesburg,PTG,ZA,Mankoeng,Limpopo,Capricorn District Municipality,AP
 PTH,PAPH,Port Heiden,56.9586396,-158.6381662,75,,America/Anchorage,PTH,US,,,,AP
-PTI,,Port Douglas,-16.48611,145.46388,29,,Australia/Brisbane,PTI,AU,Port Douglas,Queensland,Cairns,AP
 PTJ,YPOD,Portland,-38.384167,141.625,88,,Australia/Melbourne,PTJ,AU,Portland,Victoria,Glenelg,AP
 PTK,KPTK,Pontiac,42.664722,-83.41139,971,https://www.oakgov.com/aviation/ocia,America/Detroit,PTK,US,Waterford,Michigan,Oakland County,AP
 PTL,,Port Armstrong,56.297222,-134.6625,144,,America/Anchorage,PTL,US,,,,AP
@@ -6674,7 +6600,6 @@ PTN,KPTN,Williams Memorial,29.708332,-91.3375,26,,America/Chicago,PTN,US,Patters
 PTO,SBPO,Pato Branco,-26.2169937,-52.694225841764215,2687,,America/Sao_Paulo,PTO,BR,Pato Branco,Parana,Pato Branco,AP
 PTP,TFFR,Pointe-a-Pitre International Airport,16.2658457,-61.528368796666484,22,http://www.guadeloupe.aeroport.fr/,America/Guadeloupe,PTP,GP,Les Abymes,Guadeloupe,Guadeloupe,AP
 PTQ,SNMZ,Porto de Moz,-1.74273455,-52.237087731100814,26,,America/Belem,PTQ,BR,Porto de Moz,Para,Porto De Moz,AP
-PTR,,Pleasant Harbour,57.75,-152.83333,1217,,America/Anchorage,PTR,US,,,,AP
 PTS,,Atkinson Municipal Airport,37.4458828,-94.733295,921,,America/Chicago,PTS,US,Frontenac,Kansas,Crawford County,AP
 PTT,KPTT,Pratt,37.716667,-98.75,1955,,America/Chicago,PTT,US,Pratt,Kansas,Pratt County,AP
 PTU,PAPM,Platinum Airport,59.0158634,-161.8244235,29,,America/Anchorage,PTU,US,,,,AP
@@ -6690,13 +6615,11 @@ PUD,SAWD,Puerto Deseado,-47.7346017,-65.90289157339043,269,,America/Argentina/Ri
 PUE,MPOA,Puerto Obaldia,8.66932855,-77.41753081051523,32,,America/Panama,PUE,PA,Puerto Obaldia,Guna Yala,,AP
 PUF,LFBP,The Pau-Pyrenees International Airport,43.382347,-0.413573,577,,Europe/Paris,PUF,FR,Uzein,Aquitaine,Departement des Pyrenees-Atlantiques,AP
 PUG,YPAG,Port Augusta,-32.5,137.76666,22,,Australia/Adelaide,PUG,AU,Port Augusta,South Australia,Port Augusta,AP
-PUH,,Pochutla,15.733333,-96.46667,518,,America/Mexico_City,PUH,MX,San Pedro Pochutla,Oaxaca,,AP
 PUI,,Pureni,-5.833333,142.83333,5446,,Pacific/Port_Moresby,PUI,PG,,,,AP
 PUJ,MDPC,Punta Cana International Airport,18.5697918,-68.36662616922789,52,,America/Santo_Domingo,PUJ,DO,Punta Cana,San Juan,,AP
 PUK,NTGQ,Pukarua,-18.2956009,-137.0169983,22,,Pacific/Tahiti,PUK,PF,,,,AP
 PUL,83Q,Poulsbo,47.7341171,-122.648084,6,http://www.portofpoulsbo.com/seaplane-base/,America/Los_Angeles,PUL,US,Poulsbo,Washington,Kitsap County,AP
 PUN,FZOP,Punia,-1.3902988,26.3483146,1745,,Africa/Lubumbashi,PUN,CD,Kindu,Maniema,,AP
-PUO,,Prudhoe Bay,70.2527648,-148.3452926,85,,America/Anchorage,PUO,US,,,,AP
 PUP,DFCP,Po,11.183333,-1.166667,1076,,Africa/Ouagadougou,PUP,BF,,,,AP
 PUQ,SCCI,Pres Ibanez Airport,-53.005356,-70.84307,65,,America/Santiago,PUQ,CL,,,,AP
 PUR,SLPR,Puerto Rico,-11.1125,-67.52,600,,America/La_Paz,PUR,BO,,,,AP
@@ -6723,8 +6646,6 @@ PVR,MMPR,Gustavo Diaz Ordaz International Airport,20.678297,-105.24898,32,http:/
 PVS,UHMD,Provideniya,64.3800982,-173.2386276724423,187,,Asia/Anadyr,PVS,RU,Provideniya,Chukotskiy Avtonomnyy Okrug,,AP
 PVU,KPVU,Provo Airport,40.2204,-111.72097229668498,4491,http://www.provo.org/city-services/airport,America/Denver,PVU,US,Provo,Utah,Utah County,AP
 PVW,KPVW,Hale County,34.166811100000004,-101.71604068993707,3366,,America/Chicago,PVW,US,Plainview,Texas,Hale County,AP
-PVY,,Pope Vanoy,59.316666,-154.91667,2404,,America/Anchorage,PVY,US,,,,AP
-PVZ,,Casement,41.716667,-81.25,698,,America/New_York,PVZ,US,Painesville,Ohio,Lake County,AP
 PWA,KPWA,Wiley Post,35.466667,-97.53333,1220,http://www.wileypostairport.com/Home.aspx,America/Chicago,OKC,US,Oklahoma City,Oklahoma,Oklahoma County,AP
 PWD,KPWD,Sherwood,48.7886728,-104.526672,2217,http://www.co.sheridan.mt.us/index.php?airport,America/Denver,PWD,US,Plentywood,Montana,Sheridan County,AP
 PWE,UHMP,Pevek Airport,69.78489125,170.59996412000802,19,,Asia/Anadyr,PWE,RU,Pevek,Chukotskiy Avtonomnyy Okrug,,AP
@@ -6744,7 +6665,6 @@ PXL,P10,Polacca,35.8,-110.333336,5823,,America/Phoenix,PXL,US,First Mesa,Arizona
 PXM,MMPS,Puerto Escondido Airport,15.85,-97.083336,0,,America/Mexico_City,PXM,MX,Puerto Escondido,Oaxaca,San Pedro Mixtepec -Dto. 22 -,AP
 PXO,LPPS,Porto Santo Airport,33.07362365,-16.34816497905559,252,http://www.anam.pt/Porto-Santo-411.aspx,Atlantic/Madeira,PXO,PT,Vila de Porto Santo,Madeira,Porto Santo,AP
 PXR,VTUJ,Surin,14.86680565,103.4979606001036,331,,Asia/Bangkok,PXR,TH,Surin,Surin,,AP
-PXS,,Puerto De Santa Maria,36.6,-6.216667,26,,Europe/Madrid,PXS,ES,El Puerto de Santa Maria,Andalusia,Provincia de Cadiz,AP
 PXU,VVPK,Pleiku Airport,14.004424,108.0135475589313,2411,,Asia/Ho_Chi_Minh,PXU,VN,Pleiku,Gia Lai,,AP
 PYA,SKVL,Puerto Boyaca,5.966667,-74.6,544,,America/Bogota,PYA,CO,Puerto Boyaca,Boyaca,,AP
 PYB,VEJP,Jeypore,18.833332,82.63333,2834,,Asia/Kolkata,PYB,IN,Jaypur,Odisha,Koraput,AP
@@ -6762,12 +6682,10 @@ PYR,LGAD,Andravida,37.683334,21.466667,111,,Europe/Athens,PYR,GR,Pyrgos,West Gre
 PYS,,Skypark,39.710556,-121.616389,1282,http://paradiseairport.com,America/Los_Angeles,PYS,US,Paradise,California,Butte County,AP
 PYT,SNZR,Pedro Rabelo de Souza Airport,-17.242778,-46.883056,2398,,America/Sao_Paulo,PYT,BR,Paracatu,,,AP
 PYV,,Yaviza,8.152778,-77.6875,43,,America/Panama,PYV,PA,Yaviza,Darien,,AP
-PYX,,Pattaya,12.9328063,100.8980935,104,,Asia/Bangkok,PYX,TH,Phatthaya,Chon Buri,,AP
 PYY,VTCI,Pai Airport,19.37214705,98.43589618449332,1745,,Asia/Bangkok,PYY,TH,Pai,Chiang Mai,,AP
 PYZ,SPIS,Pias Airport,-7.920833,-77.525,6283,,America/Lima,PYZ,PE,,,,AP
 PZA,SKPZ,Casanare,5.877778,-71.885,826,,America/Bogota,PZA,CO,,,,AP
 PZB,FAPM,Pietermaritzburg Airport,-29.6490015,30.39693016850846,2391,,Africa/Johannesburg,PZB,ZA,Pietermaritzburg,KwaZulu-Natal,uMgungundlovu District Municipality,AP
-PZE,,Penzance,50.111942,-5.516111,0,,Europe/London,PZE,GB,Penzance,England,Cornwall,AP
 PZH,OPZB,Zhob,31.35787315,69.46402038885174,4685,,Asia/Karachi,PZH,PK,Zhob,Balochistan,,AP
 PZI,ZUZH,Pan Zhi Hua Bao An Ying,26.539592300000002,101.79735174129432,6469,,Asia/Shanghai,PZI,CN,Renhe,Sichuan,,AP
 PZK,NCPK,Puka Puka Island,-10.883333,-165.81667,0,,Pacific/Rarotonga,PZK,CK,Faleasao,Manu'a,Faleasao County,AP
@@ -6779,49 +6697,28 @@ PZU,HSPN,Port Sudan Airport,19.577778,37.21389,29,,Africa/Khartoum,PZU,SD,Port S
 PZY,LZPP,Piestany,48.621998250000004,17.82800785784479,534,http://www.ba.psg.sk/prezenta/airport-piestany/,Europe/Bratislava,PZY,SK,Piestany,Trnavsky,Okres Trnava,AP
 QAQ,LIAP,L'Aquila–Preturo Airport,42.379722,13.309167,2132,http://www.aeroportodeiparchi.it/,Europe/Rome,QAQ,IT,Preturo,Abruzzo,Provincia dell' Aquila,AP
 QBC,CYBD,Bella Coola Airport,52.333332,-126.666664,5045,,America/Vancouver,QBC,CA,,,,AP
-QCU,,Heliport,68.75,-52.333332,0,,America/Godthab,QCU,GL,,,,AP
 QCY,EGXC,Coningsby RAF Station,53.0929985046,-0.166014000773,32,http://www.raf.mod.uk/rafconingsby,Europe/London,QCY,GB,Coningsby,England,Lincolnshire,AP
 QDV,SBJD,Comte. Rolim Adolfo Amaro State Airport,-23.181667,-46.943611,2444,,America/Sao_Paulo,JDE,BR,Jundiaí,,,AP
-QFI,,Heliport,68.166664,-53.25,49,,America/Godthab,QFI,GL,,,,AP
-QFK,,Harbour,62.05,5.366667,820,,Europe/Oslo,QFK,NO,Selje,Sogn og Fjordane,Selje,AP
-QFQ,,Harbour,61.95,5.1,1286,,Europe/Oslo,QFQ,NO,Maloy,Sogn og Fjordane,Vagsoy,AP
 QGP,SNGN,Garanhuns Airport,-8.834444,-36.471389,2533,,America/Recife,QGP,BR,Garanhuns,,,AP
-QGQ,,Heliport,67.94056,-53.62278,9,,America/Godthab,QGQ,GL,Sisimiut,Qeqqata,,AP
-QGV,,Neu Isenburg,50.0501384,8.6491225,393,,Europe/Berlin,FRA,DE,Neu Isenburg,Hesse,Regierungsbezirk Darmstadt,AP
 QHU,EDXJ,Husum,54.5099983215,9.138333320620001,134,,Europe/Berlin,QHU,DE,Schwesing,Schleswig-Holstein,,AP
 QIG,SNIG,Dr. Francisco Tomé da Frota Airport,-6.347778,-39.298611,692,,America/Fortaleza,QIG,BR,Iguatu,,,AP
-QJE,,Heliport,68.833336,-53.166668,0,,America/Godthab,QJE,GL,,,,AP
-QJI,,Heliport,68.833336,-52.0,0,,America/Godthab,QJI,GL,,,,AP
-QKS,,Keystone Airport,39.7728004,-79.2110977,2496,,America/Denver,QKS,US,Elk Lick Township,Pennsylvania,Somerset County,AP
-QKU,,Messe/Deutz Rail Station,50.9406645,6.9599115,150,,Europe/Berlin,CGN,DE,Altstadt Nord,North Rhine-Westphalia,Regierungsbezirk Koln,AP
 QLR,LPMR,Leiria Gandara Airport,39.778599,-8.81972,108,,Europe/Lisbon,QLR,PT,Leiria,Leiria,Leiria,AP
-QLU,,Lublin Radawiec Airport,51.240278,22.713611,0,,Europe/Warsaw,QLU,PL,Swidnik,Lublin Voivodeship,Powiat swidnicki,AP
-QLV,,Leverkusen Mitte,51.013395900000006,7.00798689246378,0,,Europe/Berlin,QLV,DE,Leverkusen,North Rhine-Westphalia,Regierungsbezirk Koln,AP
-QMK,,Heliport,68.25,-52.833332,0,,America/Godthab,QMK,GL,,,,AP
-QMV,,Montvale,41.033333,-74.01667,0,,America/New_York,QMV,US,Montvale,New Jersey,Bergen County,AP
 QNS,SBCO,Aeroporto Campo Nossa Senhora de Fátima,-29.945556,-51.143611,23,,America/Sao_Paulo,QNS,BR,,,,AP
-QNY,,Marine Air Terminal,40.75,-74.0,0,,America/New_York,NYC,US,,,,AP
-QOR,,Ordu,38.0687895,40.9671805,0,,Asia/Istanbul,QOR,TR,Silvan,Diyarbakir,,AP
 QOW,DNIM,Sam Mbakwe International Airport,5.42797015,7.204520853248672,373,http://www.faannigeria.org/nigeria-airport.php?airport=17,Africa/Lagos,QOW,NG,Ihuo,Imo,,AP
 QPG,WSAP,Paya Lebar,1.35248525,103.89989076529653,65,,Asia/Singapore,SIN,SG,,,,AP
-QPW,,Heliport,68.25,-53.5,0,,America/Godthab,QPW,GL,,,,AP
 QRA,FAGM,Rand/Germiston,-26.140278,28.242779,5511,,Africa/Johannesburg,JNB,ZA,Boksburg,Gauteng,Ekurhuleni Metropolitan Municipality,AP
 QRO,MMQT,Queretaro Intercontinental Airport,20.6,-100.38333,6023,http://www.aiq.com.mx/,America/Mexico_City,QRO,MX,Santiago de Queretaro,Queretaro,Queretaro,AP
 QRW,DNSU,Warri,5.5985715,5.818545655443176,242,http://www.faannigeria.org/nigeria-airport.php?airport=25,Africa/Lagos,QRW,NG,Orerokpe,Delta,,AP
-QRY,,Heliport,68.15,-53.45,147,,America/Godthab,QRY,GL,Aasiaat,Qaasuitsup,,AP
 QSC,SDSC,Sao Carlos,-21.8730674,-47.90275820931602,2637,,America/Sao_Paulo,QSC,BR,Ibate,Sao Paulo,Ibate,AP
 QSF,DAAS,Setif Airport,36.18053795,5.325335614861902,3297,http://www.egsa-constantine.dz/,Africa/Algiers,QSF,DZ,Ain Arnat,Setif,,AP
-QSG,,Sonderborg,54.913811,9.792178,124,,Europe/Copenhagen,SGD,DK,,,,AP
 QSR,LIRI,Pontecagnano,40.61887125,14.911103145423613,98,http://www.aeroportosalerno.it/,Europe/Rome,QSR,IT,Pratole,Campania,Provincia di Salerno,AP
 QSZ,ZWSC,Shache Airport,38.24391405,77.0578204375604,4281,,Asia/Shanghai,QSZ,CN,Zepu,Xinjiang Uygur Zizhiqu,,AP
 QUB,HLUB,Ubari,26.6,12.766667,1528,,Africa/Tripoli,QUB,LY,Awbari,Sha`biyat Wadi al Hayat,,AP
 QUG,EGHR,Goodwood,50.941666,-0.842248,406,http://www.goodwood.co.uk/aviation/,Europe/London,QUG,GB,Milland,England,West Sussex,AP
 QUO,DNAI,Akwa Ibom Airport,4.8756716,8.097530913373072,170,http://www.ibomairport.com.ng/,Africa/Lagos,QUO,NG,Esuk Oron,Akwa Ibom,,AP
-QUP,,Heliport,70.05,-52.0,291,,America/Godthab,QUP,GL,,,,AP
 QUY,EGUY,Wyton RAF Station,52.3572006226,-0.107832998037,108,,Europe/London,QUY,GB,Hemingford Grey,England,Cambridgeshire,AP
 QWG,,Wilgrove Air Park,35.216667,-80.85,741,https://web.archive.org/web/20200910142246/http://www.wilgroveairport.net/,America/New_York,CLT,US,Charlotte,North Carolina,Mecklenburg County,AP
 QXD,SNQX,Quixadá Regional Airport,-4.978889,-38.987778,738,,America/Fortaleza,QXD,BR,Quixadá,,,AP
-QZD,,Szeged,46.245457650000006,20.091849841099055,0,,Europe/Budapest,QZD,HU,Szeged,Csongrad,,AP
 RAA,,Rakanda,-4.5,152.16667,38,,Pacific/Port_Moresby,RAA,PG,,,,AP
 RAB,AYTK,Tokua Airport,-4.340607,152.3808504456366,32,,Pacific/Port_Moresby,RAB,PG,,,,AP
 RAC,KRAC,John H. Batten Field,42.683334,-87.85,718,http://www.battenairport.aero/,America/Chicago,RAC,US,Sturtevant,Wisconsin,Racine County,AP
@@ -6853,13 +6750,11 @@ RBD,KRBD,Redbird,32.679660999999996,-96.86887702681254,629,http://www.dallasexec
 RBE,VDRK,Ratanakiri,13.666667,106.98333,800,,Asia/Phnom_Penh,RBE,KH,Ban Lung,Ratanakiri,,AP
 RBF,L35,Big Bear City Airport,34.263582,-116.85603324602909,6729,http://www.bigbearcityairport.com/,America/Los_Angeles,RBF,US,Big Bear City,California,San Bernardino County,AP
 RBG,KRBG,Roseburg Municipal Airport,43.238888,-123.35972,482,http://www.cityofroseburg.org/departments/airport/,America/Los_Angeles,RBG,US,Roseburg,Oregon,Douglas County,AP
-RBH,,Brooks Lodge,58.55,-155.8,59,,America/Anchorage,RBH,US,,,,AP
 RBI,NFFR,Rabi,15.0,-179.0,88,,Pacific/Fiji,RBI,FJ,Kekaha,Hawaii,Kauai County,AP
 RBJ,RJCR,Rebun,45.38333,141.03334,738,,Asia/Tokyo,RBJ,JP,,,,AP
 RBK,F70,French Valley,33.573875099999995,-117.12949854576331,1312,http://www.rcfva.com/,America/Los_Angeles,RBK,US,Murrieta Hot Springs,California,Riverside County,AP
 RBL,KRBL,Red Bluff Fss,40.156555,-122.27292,360,,America/Los_Angeles,RBL,US,Red Bluff,California,Tehama County,AP
 RBM,EDMS,Wallmuhle,48.90102605,12.5151349788559,1010,,Europe/Berlin,RBM,DE,Atting,Bavaria,Lower Bavaria,AP
-RBN,,Fort Jefferson,24.616667,-82.86667,0,,America/New_York,RBN,US,Key West,Florida,Monroe County,AP
 RBO,SLRB,Robore,-18.32741565,-59.765530649507966,823,,America/La_Paz,RBO,BO,Robore,Santa Cruz,,AP
 RBP,AYRE,Rabaraba,-9.969589150000001,149.83119998404325,59,,Pacific/Port_Moresby,RBP,PG,,,,AP
 RBQ,SLRQ,Rurrenabaque,-14.45,-67.55,1246,,America/La_Paz,RBQ,BO,Rurrenabaque,El Beni,,AP
@@ -6881,7 +6776,6 @@ RCL,NVSR,Redcliffe,-27.207035,153.07333,19,,Pacific/Efate,RCL,VU,Scarborough,Que
 RCM,YRMD,Richmond,-20.70389,143.11667,600,,Australia/Brisbane,RCM,AU,,,,AP
 RCN,,American River,-35.833332,138.0,278,,Australia/Adelaide,RCN,AU,Kingscote,South Australia,Kangaroo Island,AP
 RCO,LFDN,Saint Agnant,45.890218950000005,-0.9837471989711792,36,,Europe/Paris,RCO,FR,Saint-Agnant,Poitou-Charentes,Departement de la Charente-Maritime,AP
-RCP,,Cinder River,57.083057,-157.80556,144,,America/Anchorage,RCP,US,,,,AP
 RCQ,SATR,Reconquista,-29.202801899999997,-59.69118665812828,160,,America/Argentina/Cordoba,RCQ,AR,Reconquista,Santa Fe,Departamento de General Obligado,AP
 RCR,KRCR,Fulton County,41.06533295,-86.18423341947808,764,,America/Indiana/Indianapolis,RCR,US,Rochester,Indiana,Fulton County,AP
 RCS,EGTO,Rochester,51.3516919,0.5047291110496296,403,http://www.rochesterairport.co.uk/,Europe/London,RCS,GB,Rochester,England,Medway,AP
@@ -6911,12 +6805,10 @@ REC,SBRF,Guararapes-Gilberto Freyre International Airport,-8.1256775,-34.9227183
 RED,KRVL,Mifflin County,40.6775931,-77.6259185,780,http://www.mifflincountyairport.com/,America/New_York,RED,US,Church Hill,Pennsylvania,Mifflin County,AP
 REE,8XS8,Reese AFB,33.583332,-101.85,3205,http://reesetechnologycenter.com/index.php/facilities/airfield-pad-site-development,America/Chicago,LBB,US,Lubbock,Texas,Lubbock County,AP
 REG,LICR,Tito Menniti Airport,38.07528,15.650833,68,,Europe/Rome,REG,IT,Reggio Calabria,Calabria,Provincia di Reggio Calabria,AP
-REH,,Rehoboth Beach,38.7219659,-75.12238929445395,36,,America/New_York,REH,US,Rehoboth Beach,Delaware,Sussex County,AP
 REI,SOOR,Regina,4.3130527999999995,-52.133573607074794,78,,America/Cayenne,REI,GF,Roura,Guyane,Guyane,AP
 REL,SAVT,Trelew Airport,-43.2325274,-65.32400374999756,108,,America/Argentina/Catamarca,REL,AR,Trelew,Chubut,,AP
 REN,UWOO,Orenburg Airport,51.7957696,55.45557495440096,390,http://www.airoport.orenair.ru/,Asia/Yekaterinburg,REN,RU,Nezhinka,Orenburg,,AP
 REO,KREO,Rome State,42.833332,-117.61667,3704,http://www.oregon.gov/aviation/Pages/Rome.aspx,America/Los_Angeles,REO,US,Homedale,Idaho,Owyhee County,AP
-REP,VDSR,Siem Reap International Airport,13.41068555,103.81347888302334,55,http://www.cambodia-airports.com/siemreap/en,Asia/Phnom_Penh,REP,KH,Siem Reap,Siem Reap,,AP
 REQ,,Reko Diq,-5.064947,-73.86667,308,,Asia/Karachi,REQ,PK,Requena,Loreto,Provincia de Requena,AP
 RER,MGRT,Base Aerea Del Sur,14.520278,-91.696945,649,,America/Guatemala,RER,GT,Retalhuleu,Retalhuleu,Municipio de Retalhuleu,AP
 RES,SARE,Resistencia Airport,-27.4476154,-59.05377708929865,141,,America/Argentina/Cordoba,RES,AR,Fontana,Chaco,,AP
@@ -6966,13 +6858,11 @@ RIF,,Reynolds,38.74111,-112.094444,5269,,America/Denver,RIF,US,Richfield,Utah,Se
 RIG,SJRG,Rio Grande,-32.0824308,-52.16620090786992,49,,America/Sao_Paulo,RIG,BR,Rio Grande,Rio Grande do Sul,Rio Grande,AP
 RIH,MPSM,Scarlett Martínez International Airport,8.375833,-80.127778,65,,America/Panama,RIH,PA,Rio Hato,Cocle,,AP
 RIJ,SPJA,Rioja,-6.05,-77.15,2709,,America/Lima,RIJ,PE,Rioja,San Martin,Provincia de Rioja,AP
-RIK,,Carrillo,9.866667,-85.48333,22,,America/Costa_Rica,RIK,CR,Samara,Guanacaste,,AP
 RIL,KRIL,Garfield County,39.533333,-107.78333,5367,http://www.rifleairport.com/,America/Denver,RIL,US,Rifle,Colorado,Garfield County,AP
 RIM,SPLN,Rodriguez De Mendoza,-6.0,-78.0,6607,,America/Lima,RIM,PE,Churuja,Amazonas,Provincia de Bongara,AP
 RIN,AGRC,Ringi Cove,-8.2,157.03334,252,,Pacific/Guadalcanal,RIN,SB,,,,AP
 RIR,KRIR,Riverside Fla-Bob,33.9887875,-117.4099097,767,,America/Los_Angeles,RIR,US,Jurupa Valley,California,Riverside County,AP
 RIS,RJER,Rishiri Airport,45.183334,141.25,4068,,Asia/Tokyo,RIS,JP,Rishiri Town,Hokkaido,,AP
-RIT,,Rio Tigre,7.833333,-80.8,1013,,America/Panama,RIT,PA,Las Minas,Herrera,,AP
 RIV,KRIV,March ARB,33.8819433,-117.2590169,1536,,America/Los_Angeles,RIV,US,Rubidoux,California,Riverside County,AP
 RIW,KRIW,Riverton Airport,43.064445,-108.45695,5442,,America/Denver,RIW,US,Riverton,Wyoming,Fremont County,AP
 RIX,EVRA,Riga International Airport,56.922239649999995,23.97264338931523,39,http://www.riga-airport.com/,Europe/Riga,RIX,LV,Pinki,Babite,,AP
@@ -6987,12 +6877,10 @@ RJL,LERJ,Agoncillo Airport,42.46078845,-2.3237935840275643,1145,,Europe/Madrid,R
 RJM,WASN,Marinda Airport,-0.42865185,130.773097135306,65,,Asia/Jayapura,RJM,ID,Saonek,West Papua,,AP
 RJN,OIKR,Rafsanjan,30.299237849999997,56.05027354120276,5269,,Asia/Tehran,RJN,IR,Rafsanjan,Kerman,,AP
 RKA,NTKK,Aratika-Nord,-15.4861066,-145.4698939,9,,Pacific/Tahiti,RKA,PF,,,,AP
-RKC,,Yreka,41.733334,-122.63333,2608,,America/Los_Angeles,RKC,US,Yreka,California,Siskiyou County,AP
 RKD,KRKD,Knox County Regional Airport,44.06139565,-69.10293581534214,45,,America/New_York,RKD,US,South Thomaston,Maine,Knox County,AP
 RKE,EKRK,Roskilde Airport,55.5858236,12.132685539683798,167,,Europe/Copenhagen,CPH,DK,Havdrup,Zealand,Solrod Kommune,AP
 RKH,KUZA,Rock Hill,34.916668,-81.01667,613,http://www.cityofrockhill.com/departments/airport/more/airport,America/New_York,RKH,US,Rock Hill,South Carolina,York County,AP
 RKI,,Rokot,-0.95,100.75,4885,,Asia/Jakarta,RKI,ID,Sirukam,West Sumatra,,AP
-RKO,,Sipora,-2.083333,116.0,314,,Asia/Jakarta,RKO,ID,Kerang,East Kalimantan,,AP
 RKP,KRKP,Aransas County,28.033333,-97.05,39,http://aransascountyairport.com/,America/Chicago,RKP,US,Rockport,Texas,Aransas County,AP
 RKR,,Robert S Kerr,35.019388,-94.6203052,410,,America/Chicago,RKR,US,Poteau,Oklahoma,Le Flore County,AP
 RKS,KRKS,Rock Springs-Sweetwater County Airport,41.59507585,-109.06842143015916,6715,,America/Denver,RKS,US,Rock Springs,Wyoming,Sweetwater County,AP
@@ -7005,13 +6893,11 @@ RKZ,ZURK,Peace,29.351944,89.31,12470,,Asia/Shanghai,RKZ,CN,Car,Tibet Autonomous 
 RLA,,National,38.127777,-91.77805,1148,,America/Chicago,RLA,US,,,,AP
 RLD,,Richland,46.30361055,-119.30409421518716,393,,America/Los_Angeles,RLD,US,Richland,Washington,Benton County,AP
 RLG,ETNL,Laage Airport,53.919142750000006,12.276204371080205,114,,Europe/Berlin,RLG,DE,Laage,Mecklenburg-Vorpommern,,AP
-RLI,,Reilly AHP,33.666668,-85.85,692,,America/Chicago,ANB,US,Anniston,Alabama,Calhoun County,AP
 RLK,ZBYZ,Bayannur Tianjitai Airport,40.928311699999995,107.73447335946133,3362,,Asia/Shanghai,RLK,CN,Xamba,Inner Mongolia,,AP
 RLO,SAOS,Valle Del Conlara,-32.384445,-65.5525,3143,,America/Argentina/San_Luis,RLO,AR,Libertador General San Martin,San Luis,,AP
 RLP,,Rosella Plains,-18.0,145.0,1855,,Australia/Brisbane,RLP,AU,,,,AP
 RLR,,Relais de la Reine,-22.6415869,45.3258098,2618,,Indian/Antananarivo,RLR,MG,Ranohira,Ihorombe,,AP
 RLT,DRZL,Arlit,18.7905162,7.368073637080116,1361,,Africa/Niamey,RLT,NE,Arlit,Agadez,,AP
-RLU,,Bornite Upper,67.75,-156.0,2155,,America/Anchorage,RLU,US,,,,AP
 RMA,YROM,Roma Airport,-26.5423989,148.7770438,961,,Australia/Brisbane,RMA,AU,,,,AP
 RMB,OOBR,Buraimi,24.23882485,55.78885539166737,967,,Asia/Muscat,RMB,OM,Al Buraymi,Al Buraimi,,AP
 RMD,VORG,Ramagundam,18.766666,79.4,610,,Asia/Kolkata,RMD,IN,Ramgundam,Telangana,Karimnagar,AP
@@ -7082,7 +6968,6 @@ RPX,KRPX,Roundup,46.4721014,-108.549839,3484,,America/Denver,RPX,US,Roundup,Mont
 RQA,ZWRQ,Ruoqiang Loulan Airport,38.97304815,88.00915914930744,2867,,Asia/Shanghai,RQA,CN,Ruoqiang,Xinjiang Uygur Zizhiqu,,AP
 RQW,ORQW,West,35.76720047,43.125099182099994,728,,Asia/Baghdad,RQW,IQ,Ash Sharqat,Salah ad Din Governorate,,AP
 RQY,VOSH,Shivamogga Airport,13.854722,75.610556,2017,,Asia/Kolkata,RQY,IN,Sogane,Karnataka,Shimoga,AP
-RRA,,Ronda,36.75,-5.166667,2486,,Europe/Madrid,RRA,ES,Ronda,Andalusia,Provincia de Malaga,AP
 RRE,YMRE,Marree,-29.6587891,138.0707139,111,,Australia/Adelaide,RRE,AU,,,,AP
 RRG,FIMR,Rodrigues Island Airport,-19.75,63.35,0,,Indian/Mauritius,RRG,MU,Baie aux Huitres,Rodrigues,,AP
 RRI,,Barora,-7.5,158.26666,0,,Pacific/Guadalcanal,RRI,SB,,,,AP
@@ -7090,8 +6975,6 @@ RRJ,SBJR,Jacarepaguá Airport,-22.98641695,-43.371449464398225,45,https://www4.i
 RRK,VERK,Rourkela,22.25484455,84.8155119802054,620,,Asia/Kolkata,RRK,IN,Banposh,Odisha,Sundargarh,AP
 RRL,KRRL,Merrill Municipal Airport,45.1989797,-89.71268279016502,1282,http://www.ci.merrill.wi.us/index.asp?SEC=4F5D638A-3ECD-45E8-8226-20D66738C412&Type=B_BASIC,America/Chicago,RRL,US,Merrill,Wisconsin,Lincoln County,AP
 RRM,,Marromeu,-18.291566,35.93474297584764,16,,Africa/Maputo,RRM,MZ,,,,AP
-RRN,,Serra Norte,-11.0,-59.0,1092,,America/Belem,RRN,BR,Vilhena,Rondonia,Vilhena,AP
-RRO,,Sorrento,40.61667,14.366667,912,,Europe/Rome,RRO,IT,Massa Lubrense,Campania,Provincia di Napoli,AP
 RRR,NTKO,Raroia,-16.044859,-142.47556,29,,Pacific/Tahiti,RRR,PF,,,,AP
 RRS,ENRO,Roros Airport,62.580881950000006,11.34117592390011,1981,https://avinor.no/en/airport/roros-airport/,Europe/Oslo,RRS,NO,,,,AP
 RRT,KRRT,Warroad,48.9,-95.3,1059,,America/Chicago,RRT,US,,,,AP
@@ -7100,14 +6983,12 @@ RSA,SAZR,Santa Rosa Airport,-36.5872513,-64.27518346113247,583,,America/Argentin
 RSB,YRSB,Roseberth,-25.8215655,139.623569,147,,Australia/Brisbane,RSB,AU,,,,AP
 RSD,MYER,South Eleuthera Airport,24.8910397,-76.18381779273884,29,,America/Nassau,RSD,BS,Governor's Harbour,Central Eleuthera,,AP
 RSE,,Rose Bay,-33.8,151.21666,216,,Australia/Sydney,SYD,AU,Castlecrag,New South Wales,Willoughby,AP
-RSG,,Serra Pelada,-5.95,-49.65,944,,America/Belem,RSG,BR,Maraba,Para,Maraba,AP
 RSH,PARS,Russian SPB,61.783054,-161.31917,49,,America/Anchorage,RSH,US,,,,AP
 RSI,,Rio Sidra,8.966667,-80.333336,475,,America/Panama,RSI,PA,Puerto Escondido,Colon,,AP
 RSJ,W49,Rosario SPB,48.63333,-122.85,715,,America/Los_Angeles,RSJ,US,,,,AP
 RSK,WASC,Ransiki,-1.4952691,134.1726687,114,,Asia/Jayapura,RSK,ID,Ransiki,West Papua,,AP
 RSL,KRSL,Russell,38.88333,-98.85,1814,http://www.russellcity.org/airport.php,America/Chicago,RSL,US,Russell,Kansas,Russell County,AP
 RSN,KRSN,Ruston,32.5136789,-92.5890211,111,http://www.ruston.org/departments.aspx?p_PageAlias=regional-airport,America/Chicago,RSN,US,Ruston,Louisiana,Lincoln Parish,AP
-RSP,,Raspberry Strait,58.166668,-154.83333,928,,America/Anchorage,RSP,US,,,,AP
 RSS,HSDZ,Roseires,11.783333,34.4,1584,,Africa/Khartoum,RSS,SD,Ad-Damazin,Blue Nile,,AP
 RST,KRST,Rochester International Airport,43.904309749999996,-92.49544412529157,1309,,America/Chicago,RST,US,Stewartville,Minnesota,Olmsted County,AP
 RSU,RKJY,Yeosu Airport,34.84243345,127.61618910716163,32,,Asia/Seoul,RSU,KR,,,,AP
@@ -7151,7 +7032,6 @@ RVC,,Rivercess,5.4725436,-9.585146,32,,Africa/Monrovia,RVC,LR,Cestos City,River 
 RVD,SWLC,Rio Verde Airport,-17.716667,-50.933334,2627,,America/Sao_Paulo,RVD,BR,Santa Helena de Goias,Goias,Santa Helena De Goias,AP
 RVE,SKSA,Los Colonizadores,6.916667,-71.9,875,,America/Bogota,RVE,CO,Municipio de Fortul,Arauca,,AP
 RVH,ULSS,Rzhevka,59.9792581,30.578440285681754,68,http://www.airport-rzhevka.ru/,Europe/Moscow,LED,RU,Yanino Vtoroye,Leningrad,,AP
-RVI,,Rostov Airport,47.25,39.75,272,,Europe/Moscow,ROV,RU,Imeni Chkalova,Rostov,,AP
 RVK,ENRM,Ryumsjoen Airport,64.88333,11.233333,318,https://avinor.no/en/airport/rorvik-airport/,Europe/Oslo,RVK,NO,Rorvik,Nord-Trondelag,Vikna,AP
 RVN,EFRO,Rovaniemi Airport,66.561662,25.8302119,597,http://www.finavia.fi/en/rovaniemi/,Europe/Helsinki,RVN,FI,Rovaniemi,Lapland,Rovaniemi,AP
 RVO,FARI,Reivilo,-27.6,24.133333,4698,,Africa/Johannesburg,RVO,ZA,Pampierstad,North-West,,AP
@@ -7160,12 +7040,10 @@ RVS,KRVS,R.Lloyd Jones,36.15,-95.96667,731,http://www.tulsaairports.com/general-
 RVT,YNRV,Ravensthorpe,-33.797814450000004,120.20979399613981,131,,Australia/Perth,RVT,AU,Ravensthorpe,Western Australia,Ravensthorpe,AP
 RVV,NTAV,Raivavae,-25.883333,-147.65,7,,Pacific/Tahiti,RVV,PF,,,,AP
 RVY,SURV,Rivera,-30.97508805,-55.476310098194325,597,,America/Montevideo,RVY,UY,Santana do Livramento,Rio Grande do Sul,Santana Do Livramento,AP
-RWB,,Rowan Bay,56.75,-134.13333,465,,America/Anchorage,RWB,US,,,,AP
 RWF,KRWF,Redwood Falls Municipal,44.5,-95.1,1043,,America/Chicago,RWF,US,Redwood Falls,Minnesota,Redwood County,AP
 RWI,KRWI,Rocky Mount-wilson,35.854443,-77.89056,137,,America/New_York,RWI,US,Elm City,North Carolina,Wilson County,AP
 RWL,KRWL,Rawlins,41.805990949999995,-107.2037043391423,6748,http://www.wyomingairports.org/index.php?/main/airports_detail/rawlins_municipal_airport/,America/Denver,RWL,US,Rawlins,Wyoming,Carbon County,AP
 RWN,UKLR,Rovno,50.6,26.15,708,http://www.aeroport.rv.ua/,Europe/Kiev,RWN,UA,Tynne,Rivne,,AP
-RWS,,Sumare,-22.800556,-47.192223,1961,,America/Sao_Paulo,RWS,BR,Paulinia,Sao Paulo,Paulinia,AP
 RXA,,Raudha,15.433333,44.216667,7247,,Asia/Aden,RXA,YE,,,,AP
 RXE,KRXE,Madison County,43.83911,-111.85106,4852,,America/Boise,RXE,US,Rexburg,Idaho,Madison County,AP
 RXS,RPVR,Roxas City Airport,11.59774925,122.75278252625999,42,,Asia/Manila,RXS,PH,Roxas City,Western Visayas,Province of Capiz,AP
@@ -7188,7 +7066,6 @@ SAA,KSAA,Shively Field,41.4439801,-106.828107,6938,,America/Denver,SAA,US,Sarato
 SAB,TNCS,J. Yrausquin Airport,17.65,-63.216667,0,,America/Kralendijk,SAB,BQ,Upper Hell's Gate,Saba,,AP
 SAC,KSAC,Sacramento Executive Airport,38.51286,-121.4933,20,http://www.sacramento.aero/sac/,America/Los_Angeles,SAC,US,,,,AP
 SAD,KSAD,Safford,32.833332,-109.71667,2942,,America/Phoenix,SAD,US,Safford,Arizona,Graham County,AP
-SAE,,Sangir,-8.366667,118.333336,26,,Asia/Makassar,SAE,ID,Kambu,West Nusa Tenggara,,AP
 SAF,KSAF,Santa Fe,35.6175,-106.08833,6299,,America/Denver,SAF,US,La Cienega,New Mexico,Santa Fe County,AP
 SAG,VASD,Shirdi,19.6904548,74.37319208981876,1912,,Asia/Colombo,SAG,IN,Shirdi,Maharashtra,Ahmadnagar,AP
 SAH,OYSN,Sana'a International Airport,15.47740745,44.21866507285824,7185,,Asia/Aden,SAH,YE,Ar Rawdah,Amanat Al Asimah,Bani Al Harith,AP
@@ -7243,7 +7120,6 @@ SCF,KSDL,Scottsdale Airport,33.62212245,-111.91257741010094,1479,http://www.scot
 SCG,YSPK,Spring Creek,-38.016666,142.41667,367,,Australia/Brisbane,SCG,AU,,,,AP
 SCH,KSCH,Schenectady County,42.85544945,-73.92842766947919,374,http://www.schenectadycounty.com/FullStory.aspx?m=100&amid=432,America/New_York,SCH,US,,,,AP
 SCI,SVPM,San Cristobal,7.766667,-72.23333,2703,,America/Caracas,SCI,VE,San Cristobal,Tachira,Municipio San Cristobal,AP
-SCJ,,Smith Cove,55.416668,-132.33333,0,,America/Anchorage,SCJ,US,,,,AP
 SCK,KSCK,Stockton Airport,37.894444,-121.23917,3,http://www.sjgov.org/airport/,America/Los_Angeles,SAC,US,French Camp,California,San Joaquin County,AP
 SCL,SCEL,Arturo Merino Benitez Airport,-33.397175,-70.79382,1610,http://www.aeropuertosantiago.cl/ingles/index.php,America/Santiago,SCL,CL,,,,AP
 SCM,PACM,SPB,61.84639,-165.59389,0,,America/Anchorage,SCM,US,,,,AP
@@ -7273,7 +7149,6 @@ SDK,WBKS,Sandakan Airport,5.8998839499999995,118.05812026098866,49,,Asia/Kuching
 SDL,ESNN,Sundsvall-Timra Airport,62.5278157,17.44062745100433,0,,Europe/Stockholm,SDL,SE,Bergeforsen,Vaesternorrland,Timra Kommun,AP
 SDM,KSDM,Brown Field Municipalcipal,32.572224,-116.98,505,http://www.sandiego.gov/airports/brown/,America/Los_Angeles,SAN,US,,,,AP
 SDN,ENSD,Sandane Airport,61.766666,6.216667,200,https://avinor.no/en/airport/sandane-airport/,Europe/Oslo,SDN,NO,Sandane,Sogn og Fjordane,Gloppen,AP
-SDO,,Ryotsu Sado Island,38.13333,138.41667,367,,Asia/Tokyo,SDO,JP,,,,AP
 SDP,PASD,Sand Point Municipal Airport,55.316666,-160.51389,167,,America/Anchorage,SDP,US,Sand Point,Alaska,Aleutians East Borough,AP
 SDQ,MDSD,Las Americas International Airport,18.42929615,-69.6715123798729,52,http://www.aerodom.com/app/do/lasamericas.aspx,America/Santo_Domingo,SDQ,DO,Boca Chica,Santo Domingo,Santo Domingo,AP
 SDR,LEXJ,Santander Airport,43.42716075,-3.822844898531179,19,,Europe/Madrid,SDR,ES,El Astillero,Cantabria,Provincia de Cantabria,AP
@@ -7291,7 +7166,6 @@ SEE,KSEE,Gillespie Field,32.82611,-116.97222,344,http://GillespieField.com/,Amer
 SEF,KSEF,Sebring Regional Airport,27.5,-81.416664,111,http://www.sebring-airport.com/,America/New_York,SEF,US,Sebring,Florida,Highlands County,AP
 SEG,KSEG,Penn Valley,40.8167514,-76.863304,456,http://www.dot.state.pa.us/Internet/Bureaus/pdBOA.nsf/AviationHomepage?openframeset,America/New_York,SEG,US,Hummels Wharf,Pennsylvania,Snyder County,AP
 SEH,WAJS,Senggeh,-3.43980705,140.77864699543625,803,,Asia/Jayapura,SEH,ID,Sengge,Papua,,AP
-SEI,,Senhor Do Bonfim,-10.45,-40.183334,1883,,America/Bahia,SEI,BR,Senhor do Bonfim,Bahia,Senhor Do Bonfim,AP
 SEK,UESK,Srednekolymsk Airport,67.4746917,153.72998522576762,42,,Asia/Srednekolymsk,SEK,RU,Srednekolymsk,Sakha,,AP
 SEM,KSEM,Craig AFB,32.226112,-87.08722,147,http://www.craigcomplex.com/,America/Chicago,SES,US,Selmont-West Selmont,Alabama,Dallas County,AP
 SEN,EGMC,London Southend Airport,51.570227599999996,0.6966132970490921,42,http://www.southendairport.com/,Europe/London,LON,GB,Rochford,England,Essex,AP
@@ -7320,14 +7194,11 @@ SFL,GVSF,Sao Filipe,14.8857869,-24.480895853305185,538,,Atlantic/Cape_Verde,SFL,
 SFM,KSFM,Sanford,43.433334,-70.76667,275,http://www.sanfordmaine.org/index.asp?Type=B_BASIC&SEC={DEE316C2-D149-450A-922E-9B2B686815B4},America/New_York,SFM,US,Sanford (historical),Maine,York County,AP
 SFN,SAAV,Santa Fe Airport,-31.70823055,-60.80930044284597,39,,America/Argentina/Cordoba,SFN,AR,Santo Tome,Santa Fe,,AP
 SFO,KSFO,San Francisco International Airport,37.622451999999996,-122.38407160781362,26,http://www.flysfo.com/,America/Los_Angeles,SFO,US,Millbrae,California,San Mateo County,AP
-SFP,,Surfers Paradise,-28.0,153.0,147,,Australia/Brisbane,SFP,AU,Cedar Vale,Queensland,Logan,AP
 SFQ,LTCH,Sanliurfa,37.09342925,38.847883721513895,1453,,Europe/Istanbul,GNY,TR,Sanliurfa,Sanliurfa,,AP
-SFR,,San Fernando,34.266666,-118.433334,977,,America/Los_Angeles,SFR,US,San Fernando,California,Los Angeles County,AP
 SFS,RPLB,Subic Bay International,14.7937674,120.26870192132773,42,,Asia/Manila,SFS,PH,Subic Bay Freeport Zone,,,AP
 SFT,ESNS,Skelleftea Airport,64.6246447,21.0699419,118,,Europe/Stockholm,SFT,SE,Soedra Bergsbyn,Vaesterbotten,Skelleftea Kommun,AP
 SFU,AYSF,Safia,-9.666667,148.66667,994,,Pacific/Port_Moresby,SFU,PG,,,,AP
 SFV,,Santa Fe Do Sul,-19.833332,-50.166668,1443,,America/Sao_Paulo,SFV,BR,Iturama,Minas Gerais,Iturama,AP
-SFW,,Santa Fe,8.833333,-81.166664,0,,America/Panama,SFW,PA,Canazas,Veraguas,,AP
 SFX,SVMU,San Felix,8.216667,-62.38333,885,,America/Caracas,SFX,VE,Upata,Bolivar,Municipio Piar,AP
 SFY,,Tri-Township Airport,42.04550795,-90.10958890991054,590,,America/Chicago,SFY,US,Savanna,Illinois,Carroll County,AP
 SFZ,KSFZ,North Central,41.916668,-71.566666,416,,America/New_York,SFZ,US,Smithfield,Rhode Island,Providence County,AP
@@ -7337,7 +7208,6 @@ SGC,USRR,Surgut Airport,61.3414657,73.4052099844604,150,,Asia/Yekaterinburg,SGC,
 SGD,EKSB,Sonderborg Airport,54.9625495,9.792646648299392,26,,Europe/Copenhagen,SGD,DK,Sonderborg,South Denmark,Sonderborg Kommune,AP
 SGE,EDGS,Siegerland Airport,50.85,8.0,810,,Europe/Berlin,SGE,DE,Siegen,North Rhine-Westphalia,Regierungsbezirk Arnsberg,AP
 SGF,KSGF,Springfield-Branson National Airport,37.2393873,-93.39661262453578,1289,http://www.sgf-branson-airport.com,America/Chicago,SGF,US,Willard,Missouri,Greene County,AP
-SGG,,Simanggang,1.222778,111.460556,32,,Asia/Kuching,SGG,MY,,,,AP
 SGH,KSGH,Springfield,39.916668,-83.8,1013,http://www.airparkohio.com/beckly_airport.html,America/New_York,SGH,US,Springfield,Ohio,Clark County,AP
 SGI,OPSR,Mushaf Air Base,32.0486,72.665,607,,Asia/Karachi,SGI,PK,,,,AP
 SGJ,,Sagarai,-10.466667,150.15,95,,Pacific/Port_Moresby,SGJ,PG,,,,AP
@@ -7349,7 +7219,6 @@ SGO,YSGE,St George,-28.052005700000002,148.59868091576283,643,,Australia/Brisban
 SGP,YSHG,Shay Gap,-20.816668,120.23333,741,,Australia/Perth,SGP,AU,,,,AP
 SGQ,WALA,Sanggata,0.5,117.3333588,426,,Asia/Makassar,SGQ,ID,Sangatta,East Kalimantan,,AP
 SGR,KSGR,Sugar Land Regional,29.698889,-95.407776,52,http://www.sugarlandtx.gov/index.aspx?nid=1073,America/Chicago,SGR,US,Southside Place,Texas,Harris County,AP
-SGS,,Sanga Sanga,5.233333,121.15,0,,Asia/Manila,SGS,PH,Latung,Autonomous Region in Muslim Mindanao,Province of Sulu,AP
 SGT,KSGT,Stuttgart Municipalcipal,34.5,-91.53333,187,http://www.stuttgartarkansas.org/work/stuttgart_municipal_airport.aspx,America/Chicago,SGT,US,Stuttgart,Arkansas,Arkansas County,AP
 SGU,KSGU,Saint George Municipal Airport,37.032627,-113.51017,2834,http://www.sgcity.org/departments/publicworks/airport/,America/Denver,SGU,US,Washington,Utah,Washington County,AP
 SGV,SAVS,Sierra Grande,-41.5883936,-65.33930185138708,715,,America/Argentina/Salta,SGV,AR,Sierra Grande,Rio Negro,,AP
@@ -7372,7 +7241,6 @@ SHL,VEBI,Shillong Airport,25.566668,91.88333,4960,,Asia/Kolkata,SHL,IN,Shillong,
 SHM,RJBD,Shirahama Airport,33.66245835,135.36280893177445,259,,Asia/Tokyo,SHM,JP,Tanabe,Wakayama,,AP
 SHN,KSHN,Sanderson Field,47.2334272,-123.147374,249,http://www.portofshelton.com/airport.html,America/Los_Angeles,SHN,US,Shelton,Washington,Mason County,AP
 SHO,RKND,King Mswati III International Airport,38.13333,128.6,164,http://www.eswacaa.co.sz/airports/kingmswatiIII/,Africa/Mbabane,MTS,SZ,,,,AP
-SHP,,Qinhuangdao,39.965214,119.71656,39,,Asia/Shanghai,SHP,CN,Shanhaiguan,Hebei,,AP
 SHQ,YSPT,Southport,-27.951944,153.42778,22,,Australia/Brisbane,SHQ,AU,Main Beach,Queensland,Gold Coast,AP
 SHR,KSHR,Sheridan,44.774166,-106.97722,3979,,America/Denver,SHR,US,Sheridan,Wyoming,Sheridan County,AP
 SHS,ZHSS,Shashi,30.316668,112.23333,144,,Asia/Shanghai,SHS,CN,Shashi,Hubei,,AP
@@ -7421,7 +7289,6 @@ SJI,RPUH,San Jose,12.36166935,121.04458254709422,22,,Asia/Manila,SJI,PH,Babug,Mi
 SJJ,LQSA,Sarajevo International Airport,43.8253475,18.333154918143215,1673,http://www.sarajevo-airport.ba/,Europe/Sarajevo,SJJ,BA,Sarajevo,Federation of Bosnia and Herzegovina,Kanton Sarajevo,AP
 SJK,SBSJ,Sao Jose Dos Campos,-23.183332,-46.11667,2303,,America/Sao_Paulo,SJK,BR,Santa Isabel,Sao Paulo,Santa Isabel,AP
 SJL,SBUA,Da Cachoeira,-0.1483109,-66.98557275279653,239,,America/Manaus,SJL,BR,Sao Gabriel da Cachoeira,Amazonas,Sao Gabriel Da Cachoeira,AP
-SJM,,San Juan,18.833332,-71.23333,1407,,America/Santo_Domingo,SJM,DO,San Juan de la Maguana,San Juan,,AP
 SJN,KSJN,St. Johns Industrial Air Park,34.52054225,-109.37834294269751,5748,,America/Phoenix,SJN,US,Saint Johns,Arizona,Apache County,AP
 SJO,MROC,Juan Santamaria International Airport,9.993411550000001,-84.21152052685673,2962,,America/Costa_Rica,SJO,CR,Alajuela,Alajuela,,AP
 SJP,SBSR,Sao Jose do Rio Preto Airport,-20.81731545,-49.408467700474546,1755,,America/Sao_Paulo,SJP,BR,Sao Jose do Rio Preto,Sao Paulo,Sao Jose Do Rio Preto,AP
@@ -7516,7 +7383,6 @@ SMZ,SMST,Stoelmans Eiland,4.3500591,-54.41691100927227,141,,America/Paramaribo,S
 SNA,KSNA,John Wayne Airport,33.67420559999999,-117.86801480770461,45,http://www.ocair.com/,America/Los_Angeles,SNA,US,Irvine,California,Orange County,AP
 SNB,YSNB,Snake Bay,-11.41888685,130.64965697107698,154,,Australia/Darwin,SNB,AU,Leanyer,Northern Territory,Darwin,AP
 SNC,SESA,General Ulpiano Paez Airport,-2.2,-80.98333,29,,America/Guayaquil,SNC,EC,Salinas,Santa Elena,Canton Salinas,AP
-SND,,Seno,16.666668,105.01667,610,,Asia/Vientiane,SND,LA,Wan Yai,Mukdahan,,AP
 SNE,GVSN,Preguica,16.58982335,-24.286408063861867,597,,Atlantic/Cape_Verde,SNE,CV,Vila da Ribeira Brava,Ribeira Brava,,AP
 SNF,SVSP,San Felipe,10.280278,-68.75389,816,,America/Caracas,SNF,VE,Boraure,Yaracuy,Municipio La Trinidad,AP
 SNG,SLSI,San Ignacio De Velasco,-16.383057,-60.97639,1397,,America/La_Paz,SNG,BO,San Ignacio de Velasco,Santa Cruz,,AP
@@ -7547,7 +7413,6 @@ SOE,FCOS,Souanke,1.9983256,14.1742168,1735,,Africa/Brazzaville,SOE,CG,Sembe,Sang
 SOF,LBSF,Sofia Airport,42.69557455,23.414218088581656,1722,http://sofia-airport.bg,Europe/Sofia,SOF,BG,Sofia,Sofia-Capital,Stolichna Obshtina,AP
 SOG,ENSG,Sogndal Airport,61.155940099999995,7.1358296520257785,1633,https://avinor.no/en/airport/sogndal-airport/,Europe/Oslo,SOG,NO,Sogndalsfjora,Sogn og Fjordane,Sogndal,AP
 SOH,,Solita,9.2,-71.76667,52,,America/Bogota,SOH,CO,,,,AP
-SOI,,South Molle Island,-20.75,148.58333,187,,Australia/Brisbane,SOI,AU,,,,AP
 SOJ,ENSR,Sorkjosen Airport,69.78735975000001,20.95955849087061,26,https://avinor.no/en/airport/sorkjosen-airport/,Europe/Oslo,SOJ,NO,Storslett,Troms,Nordreisa,AP
 SOK,FXSM,Semongkong,-29.833332,28.5,8690,,Africa/Maseru,SOK,LS,Thaba-Tseka,Thaba-Tseka,,AP
 SOL,AK26,Solomon,64.56084,-164.44028,36,,America/Anchorage,SOL,US,,,,AP
@@ -7577,9 +7442,7 @@ SPJ,LGSP,Eleftherios Venizelos,36.983334,22.533333,364,,Europe/Athens,SPJ,GR,Kro
 SPK,,Sapporo Metropolitan Area,43.09367523914,41.3405138551,3835,,Asia/Tokyo,SPK,JP,Sapporo,Hokaido,,AP
 SPM,ETAD,Spangdahlem,50.06547,6.835917,1240,http://www.spangdahlem.af.mil/,Europe/Berlin,SPM,DE,Pantenburg,Rheinland-Pfalz,,AP
 SPN,PGSN,Saipan International Airport,15.12049075,145.72962519467052,196,,Pacific/Saipan,SPN,MP,Saipan,Saipan,,AP
-SPO,,San Pablo,37.38333,-5.75,469,,Europe/Madrid,SPO,ES,Mairena del Alcor,Andalusia,Provincia de Sevilla,AP
 SPP,FNME,Menongue,-14.65800685,17.71826276366948,4632,,Africa/Luanda,SPP,AO,Menongue,Cuando Cubango,,AP
-SPQ,,Catalina SPB,33.750557,-118.27278,0,,America/Los_Angeles,SPQ,US,San Pedro,California,Los Angeles County,AP
 SPR,MZSP,San Pedro,17.9141504,-87.9708621044903,26,,America/Belize,SPR,BZ,San Pedro,Belize,,AP
 SPS,KSPS,Sheppard AFB,33.98750455,-98.50127258819343,987,http://www.flywichitafalls.net/,America/Chicago,SPS,US,Wichita Falls,Texas,Wichita County,AP
 SPT,,Sipitang,5.083333,115.55,0,,Asia/Kuching,SPT,MY,Beaufort,Sabah,,AP
@@ -7659,7 +7522,6 @@ SSQ,CSR8,La Sarre,48.91712455,-79.17988932378344,1010,http://www.ville.lasarre.q
 SSR,NVSH,Sara,-15.5,168.3,0,,Pacific/Efate,SSR,VU,,,,AP
 SSS,,Siassi,-5.5971687,147.81102083962213,1194,,Pacific/Port_Moresby,SSS,PG,,,,AP
 SST,SAZL,Santa Teresita,-33.416668,-60.783333,157,,America/Argentina/Buenos_Aires,SST,AR,Arroyo Seco,Santa Fe,,AP
-SSU,,Greenbrier,37.8,-80.3,1860,,America/New_York,SSU,US,White Sulphur Springs,West Virginia,Greenbrier County,AP
 SSV,,Siasi,5.5,120.816666,0,,Asia/Manila,SSV,PH,Manubul,Autonomous Region in Muslim Mindanao,Province of Sulu,AP
 SSW,7WA5,Stuart Island,48.6835888,-123.21977,95,,America/Los_Angeles,SSW,US,,,,AP
 SSX,FASP,Samsun Samair Airport,41.276765,36.336289,200,,Europe/Istanbul,SSX,TR,Samsun,Samsun,,AP
@@ -7684,7 +7546,6 @@ STQ,KOYM,St Marys,41.433334,-78.566666,1725,http://stmarysmunicipalairport.com/,
 STR,EDDS,Stuttgart Airport,48.69073,9.193624,1312,http://www.flughafen-stuttgart.de/,Europe/Berlin,STR,DE,Leinfelden-Echterdingen,Baden-Wuerttemberg,Regierungsbezirk Stuttgart,AP
 STS,KSTS,Sonoma County Airport,38.5100124,-122.7842318,131,http://www.sonomacountyairport.org/,America/Los_Angeles,STS,US,Windsor,California,Sonoma County,AP
 STT,TIST,Cyril E. King Airport,18.3346729,-64.9701668,16,http://www.viport.com/airports.html,America/St_Thomas,STT,VI,Charlotte Amalie,Saint Thomas Island,,AP
-STU,,Santa Cruz,18.266666,-88.45,16,,America/Belize,STU,BZ,Corozal,Corozal,,AP
 STV,VASU,Surat Gujarat Airport,21.1168313,72.74226530410085,36,,Asia/Kolkata,STV,IN,Surat,Gujarat,Surat,AP
 STW,URMT,Stavropol Airport,45.333332,42.00833,971,,Europe/Moscow,STW,RU,Moskovskoye,Stavropol'skiy,,AP
 STX,TISX,Henry E. Rohlsen Airport,17.69997805,-64.8059208987329,39,,America/St_Thomas,STX,VI,Saint Croix,Saint Croix Island,,AP
@@ -7692,7 +7553,6 @@ STY,SUSO,Salto,-31.436666,-57.988335,65,,America/Montevideo,STY,UY,Concordia,Ent
 STZ,SWST,Confresa,-10.300278,-50.45,583,,America/Cuiaba,STZ,BR,,,,AP
 SUA,KSUA,Witham Field,27.1831531,-80.22488623222156,16,"http://ap3server.martin.fl.us/portal/page?_pageid=413,234422&_dad=portal&_schema=PORTAL",America/New_York,SUA,US,Stuart,Florida,Martin County,AP
 SUB,WARR,Juanda International Airport,-7.38007105,112.78532737805308,19,http://www.juanda-airport.com/,Asia/Jakarta,SUB,ID,Semampirbarat,East Java,,AP
-SUC,,Schloredt,44.3922301,-104.4113572,4914,,America/Denver,SUC,US,Sundance,Wyoming,Crook County,AP
 SUD,KSUD,Stroud,35.75,-96.683334,951,,America/Chicago,SUD,US,Stroud,Oklahoma,Lincoln County,AP
 SUE,KSUE,Door County,44.84191575,-87.42258867946383,715,http://map.co.door.wi.us/airport/,America/Chicago,SUE,US,Sturgeon Bay,Wisconsin,Door County,AP
 SUF,LICA,Lamezia Terme International Airport,38.9062877,16.24275952965428,32,,Europe/Rome,SUF,IT,Santa Eufemia Lamezia,Calabria,Provincia di Catanzaro,AP
@@ -7766,9 +7626,7 @@ SWX,FBSW,Shakawe,-18.373261149999998,21.8361789268602,3277,http://www.dca.gov.bw
 SWY,WMBA,Sitiawan,4.22234085,100.69948385000001,42,,Asia/Kuala_Lumpur,SWY,MY,Lumut,Perak,,AP
 SXA,AYQS,Sialum,-6.033333,147.61667,0,,Pacific/Port_Moresby,SXA,PG,Finschhafen,Morobe,,AP
 SXB,LFST,Strasbourg Airport,48.538652549999995,7.625009702296425,498,http://www.strasbourg.aeroport.fr/E/index.php,Europe/Paris,SXB,FR,,,,AP
-SXC,,Avalo Vor/WP,33.5,-118.416664,0,,America/Los_Angeles,AVX,US,,,,AP
 SXE,YWSL,Sale,-38.166668,147.0,65,,Australia/Melbourne,SXE,AU,Sale,Victoria,Wellington,AP
-SXF,,Schonefeld Airport,52.3663978,13.489561415210032,137,,Europe/Berlin,BER,DE,Schonefeld,Brandenburg,,AP
 SXG,FLSN,Senanga,-16.113010799999998,23.29875591158206,3316,,Africa/Lusaka,SXG,ZM,Senanga,Western,,AP
 SXH,AYSL,Sehulea,-9.96508625,151.16207079487572,22,,Pacific/Port_Moresby,SXH,PG,,,,AP
 SXI,OIBS,Sirri Island,25.908850700000002,54.540427980277315,42,,Asia/Tehran,SXI,IR,Abu Musa,Hormozgan,,AP
@@ -7799,7 +7657,6 @@ SYH,VNSB,Syangboche,27.8113479,86.71234315904579,12270,,Asia/Kathmandu,SYH,NP,Na
 SYI,KSYI,Bomar Field,35.5612926,-86.44269606008433,777,http://www.shelbyvilletnairport.org/,America/Chicago,SYI,US,Shelbyville,Tennessee,Bedford County,AP
 SYJ,OIKY,Sirjan,29.551598849999998,55.666425658766634,5807,,Asia/Tehran,SYJ,IR,Sirjan,Kerman,,AP
 SYK,BIST,Stykkisholmur,65.1,-22.8,0,,Atlantic/Reykjavik,SYK,IS,Stykkisholmur,West,,AP
-SYL,,Roberts AAF,35.75,-120.7,692,,America/Los_Angeles,SYL,US,San Miguel,California,San Luis Obispo County,AP
 SYM,ZPSM,Pu'er Simao Airport,22.79187385,100.95929898984352,4087,,Asia/Shanghai,SYM,CN,Simao,Yunnan,,AP
 SYN,KSYN,Carleton,32.13333,-101.8,2667,,America/Chicago,SYN,US,Stanton,Texas,Martin County,AP
 SYO,RJSY,Shonai Airport,38.815828550000006,139.78777585339822,95,,Asia/Tokyo,SYO,JP,Tsuruoka,Yamagata,,AP
@@ -7816,7 +7673,6 @@ SYY,EGPO,Stornoway Airport,58.2143799,-6.32651344733495,26,http://www.hial.co.uk
 SYZ,OISS,Shiraz International Airport,29.5424396,52.580523125907916,4927,http://shirazairport.ir/,Asia/Tehran,SYZ,IR,Shiraz,Fars,,AP
 SZA,FNSO,Soyo Airport,-6.033333,12.416667,15,,Africa/Luanda,SZA,AO,Soio,Zaire,,AP
 SZB,WMSA,Sultan Abdul Aziz Shah Airport,3.1308814500000004,101.55028764274799,90,,Asia/Kuala_Lumpur,KUL,MY,Kampung Baru Subang,Selangor,,AP
-SZC,,Guanacaste,10.254722,-85.58417,0,,America/Costa_Rica,SZC,CR,,,,AP
 SZE,HASM,Semera Airport,11.5,41.083332,1390,,Africa/Addis_Ababa,SZE,ET,Dubti,Afar,,AP
 SZF,LTFH,Samsun-Carsamba Airport,41.2562275,36.5547365620795,18,http://www.carsamba.dhmi.gov.tr/havaalanlari/default.aspx?hv=32,Europe/Istanbul,SZF,TR,Dikbiyik,Samsun,,AP
 SZG,LOWS,W. A. Mozart Salzburg Airport,47.791225,12.997331,1411,http://www.salzburg-airport.com/,Europe/Vienna,SZG,AT,,,,AP
@@ -7828,10 +7684,8 @@ SZL,KSZL,Whiteman AFB,38.766666,-93.73333,870,http://www.whiteman.af.mil/,Americ
 SZM,FYSS,Sesriem,-24.583332,15.833333,2454,,Africa/Windhoek,SZM,NA,Maltahohe,Hardap,,AP
 SZN,KSZN,Santa Cruz Island,34.0589776,-119.9151998,50,,America/Los_Angeles,SBA,US,Isla Vista,California,Santa Barbara County,AP
 SZP,KSZP,Oxnard,34.35,-119.066666,243,,America/Los_Angeles,SZP,US,Santa Paula,California,Ventura County,AP
-SZQ,,Saenz Pena,-34.61667,-58.533333,0,,America/Argentina/Buenos_Aires,SZQ,AR,Caseros,Buenos Aires,,AP
 SZR,LBSZ,Stara Zagora,42.433334,25.616667,558,,Europe/Sofia,SZR,BG,Stara Zagora,Stara Zagora,Obshtina Stara Zagora,AP
 SZS,NZRC,Stewart Island,-47.0,167.86667,62,,Pacific/Auckland,SZS,NZ,Bluff,Southland,Invercargill City,AP
-SZT,,San Cristobal Airport,16.690556,-92.54417,0,,America/Mexico_City,SZT,MX,Mitziton,Chiapas,San Cristobal De Casas,AP
 SZU,,Segou,13.433333,-6.283333,0,,Africa/Bamako,SZU,ML,Segou,Segou,,AP
 SZV,ZSSZ,Suzhou,31.3,120.63333,0,,Asia/Shanghai,SZV,CN,Shuangta,Jiangsu Sheng,,AP
 SZW,EDOP,Parchim Airport,53.433334,11.783333,166,,Europe/Berlin,SZW,DE,Domsuhl,Mecklenburg-Vorpommern,,AP
@@ -8032,7 +7886,6 @@ TIO,VYHN,Tilin,20.0,96.0,1385,,Asia/Rangoon,TIO,MM,Nay Pyi Taw,Mandalay,,AP
 TIP,HLLT,Tripoli International Airport,32.6682804,13.14624729995671,263,,Africa/Tripoli,TIP,LY,Al 'Aziziyah,Sha`biyat al Jafarah,,AP
 TIQ,PGWT,Tinian International,14.99833865,145.6183628291265,271,,Pacific/Saipan,TIQ,MP,San Jose Village,Tinian,,AP
 TIR,VOTP,Tirupati Airport,13.63291745,79.54291963437294,350,http://aai.aero/allAirports/tirupati_generalinfo.jsp,Asia/Kolkata,TIR,IN,Renigunta,Andhra Pradesh,Chittoor,AP
-TIS,,Thursday Island,-10.5,142.05,0,,Australia/Brisbane,TIS,AU,,,,AP
 TIU,NZTU,Timaru Airport,-44.29991735,171.22451732612393,89,,Pacific/Auckland,TIU,NZ,Timaru,Canterbury,Timaru District,AP
 TIV,LYTV,Tivat Airport,42.403729850000005,18.724834448309945,20,http://www.montenegroairports.com/?menu=3,Europe/Podgorica,TIV,ME,Tivat,Tivat,,AP
 TIW,KTIW,Industrial,47.270557,-122.57306,294,,America/Los_Angeles,TIW,US,Wollochet,Washington,Pierce County,AP
@@ -8085,7 +7938,6 @@ TLC,MMTO,Toluca International Airport,19.283333,-99.666664,8466,,America/Mexico_
 TLD,FBLV,Limpopo Valley,-22.192227449999997,29.132088297657788,1772,,Africa/Gaborone,TLD,BW,Mathathane,Central,,AP
 TLE,FMST,Tulear,-23.389723,43.724167,29,,Indian/Antananarivo,TLE,MG,Toliara,Atsimo-Andrefana,Toliara I District,AP
 TLF,2K5,Telida,63.666668,-152.5,650,,America/Anchorage,TLF,US,Y,Alaska,Matanuska-Susitna Borough,AP
-TLG,,Tulagi Island,-9.1,160.15,0,,Pacific/Guadalcanal,TLG,SB,Tulaghi,Central Province,,AP
 TLH,KTLH,Tallahassee International Airport,30.39782605,-84.35908394368526,81,,America/New_York,TLH,US,Tallahassee,Florida,Leon County,AP
 TLI,WAMI,Tolitoli,1.033333,120.816666,40,,Asia/Makassar,TLI,ID,Tolitoli,Central Sulawesi,,AP
 TLJ,PATL,Tatalina AFS,62.885277,-155.96806,964,,America/Anchorage,TLJ,US,,,,AP
@@ -8192,7 +8044,6 @@ TPJ,VNTJ,Taplejung Suketar,27.35088365,87.69565259671111,7990,,Asia/Kathmandu,TP
 TPK,WITA,Tapaktuan,3.266667,97.183334,17,,Asia/Jakarta,TPK,ID,Tapaktuan,Aceh,,AP
 TPL,KTPL,Draughon-miller Central Texas Regional,31.150278,-97.409164,682,,America/Chicago,TPL,US,Morgans Point Resort,Texas,Bell County,AP
 TPN,SETI,Tiputini,-0.77613245,-75.52839598806818,997,,America/Guayaquil,TPN,EC,Pantoja,Loreto,Provincia de Maynas,AP
-TPO,,Tanalian Point,60.2029778,-154.3191843,0,,America/Anchorage,TPO,US,Anchor Point,Alaska,Kenai Peninsula Borough,AP
 TPP,SPST,Cad. FAP Guillermo del Castillo Paredes Airport,-6.511111,-76.39861,869,,America/Lima,TPP,PE,Tarapoto,San Martin,Provincia de San Martin,AP
 TPQ,MMEP,Tepic Airport,21.5,-104.9,3020,http://tepic.asa.gob.mx/wb/webasa/tepic_aeropuertos,America/Mazatlan,TPQ,MX,Tepic,Nayarit,,AP
 TPR,YTMP,Tom Price,-22.75,117.666664,2300,,Australia/Perth,TPR,AU,,,,AP
@@ -8206,7 +8057,6 @@ TQN,OATQ,Taluqan,36.77068975,69.53020884790408,2606,,Asia/Kabul,TQN,AF,Taloqan,T
 TQO,MMTL,Aeropuerto Internacional de Tulum Felipe Carrillo Puerto,20.165842,-87.659709,86,,America/Cancun,TQO,MX,Tulum,,,AP
 TQP,YTEE,Trepell Airport,-21.8402176,140.894352,891,,Australia/Brisbane,TQP,AU,,,,AP
 TQQ,WA44,Maranggo Airport,-5.7645702,123.9169998,169,,Asia/Makassar,TQQ,ID,Lasehao,Sulawesi Tenggara,,AP
-TQR,,San Domino Island,42.11667,15.483333,0,,Europe/Rome,TQR,IT,Isole Tremiti,Apulia,Provincia di Foggia,AP
 TQS,SKTQ,Tres Esquinas,0.733333,-75.23333,585,,America/Bogota,TQS,CO,Solano,Caqueta,,AP
 TRA,RORT,Tarama,24.653999050000003,124.67635410839722,36,,Asia/Tokyo,TRA,JP,Hirara,Okinawa,,AP
 TRB,SKTU,Gonzalo,8.078333,-76.748055,6,,America/Bogota,TRB,CO,Turbo,Antioquia,,AP
@@ -8223,7 +8073,6 @@ TRL,KTRL,Terrell Field,32.735832,-96.275,474,http://www.terrellairport.com/,Amer
 TRM,KTRM,Thermal,33.630554,-116.93611,-115,http://www.rcjcra.com/,America/Los_Angeles,TRM,US,East Hemet,California,Riverside County,AP
 TRN,LIMF,Turin Airport,45.20096875,7.648975075273562,989,http://www.aeroportoditorino.it/,Europe/Rome,TRN,IT,Caselle Torinese,Piedmont,Provincia di Torino,AP
 TRO,YTRE,Taree Airport,-31.8877679,152.51309188792249,38,,Australia/Sydney,TRO,AU,Cundletown,New South Wales,Greater Taree,AP
-TRP,,Tree Point Heliport,57.353380232532,-154.052675125,0,,America/Anchorage,TRP,US,,,,AP
 TRQ,SBTK,Tarauaca,-8.1,-70.75,646,,America/Rio_Branco,TRQ,BR,Tarauaca,Acre,Tarauaca,AP
 TRR,VCCT,China Bay,8.5387065,81.182420993587,6,,Asia/Colombo,TRR,LK,Trincomalee,Eastern Province,,AP
 TRS,LIPQ,Trieste - Friuli Venezia Giulia Airport,45.8261611,13.473368702886166,39,http://www.aeroporto.fvg.it/,Europe/Rome,TRS,IT,Ronchi dei Legionari,Friuli Venezia Giulia,Provincia di Gorizia,AP
@@ -8247,11 +8096,9 @@ TSK,,Taskul,-2.566667,150.41667,100,,Pacific/Port_Moresby,TSK,PG,Kavieng,New Ire
 TSL,MMTN,Tamuin,21.983334,-98.75,164,,America/Mexico_City,TSL,MX,Tamuin,San Luis Potosi,,AP
 TSM,KSKX,Taos,36.442847099999994,-105.66894183952934,7095,http://www.taosairport.org/,America/Denver,TSM,US,Taos,New Mexico,Taos County,AP
 TSN,ZBTJ,Tianjin Binhai International Airport,39.12745995,117.35483617593881,10,,Asia/Shanghai,TSN,CN,,,,AP
-TSO,,Tresco,49.945557,-6.331389,0,,Europe/London,ISC,GB,Hugh Town,England,Isles of Scilly,AP
 TSP,KTSP,Kern County,35.1375,-118.441666,4001,http://www.liveuptehachapi.com/index.aspx?nid=26,America/Los_Angeles,TSP,US,Tehachapi,California,Kern County,AP
 TSQ,SBTR,Torres,-29.3325,-49.746113,26,,America/Sao_Paulo,TSQ,BR,Torres,Rio Grande do Sul,Torres,AP
 TSR,LRTR,Timisoara Traian Vuia International Airport,45.809854400000006,21.33283281275959,348,http://www.aerotim.ro/,Europe/Bucharest,TSR,RO,Giarmata-Vii,Timis,Comuna Ghiroda,AP
-TSS,,East 34th St Heliport,40.766666,-74.166664,0,,America/New_York,NYC,US,East Newark,New Jersey,Hudson County,AP
 TST,VTST,Trang Airport,7.5113368,99.615389,67,,Asia/Bangkok,TST,TH,Trang,Trang,,AP
 TSU,NGTS,Tabiteuea South,-1.416667,174.83333,0,,Pacific/Tarawa,TSU,KI,Temaiku Village,Gilbert Islands,Tarawa,AP
 TSV,YBTL,Townsville Airport,-19.2518982,146.77447438460155,18,http://www.townsvilleairport.com.au/,Australia/Brisbane,TSV,AU,Townsville,Queensland,Townsville,AP
@@ -8283,10 +8130,8 @@ TUA,SETU,Tulcan,0.8096193,-77.70792372481476,9649,,America/Guayaquil,TUA,EC,Tulc
 TUB,NTAT,Tubuai,-23.35,-149.46666,7,,Pacific/Tahiti,TUB,PF,Moerai,Iles Australes,,AP
 TUC,SANT,Benj Matienzo,-26.833332,-65.2,1493,,America/Argentina/Tucuman,TUC,AR,San Miguel de Tucuman,Tucuman,,AP
 TUD,GOTT,Tambacounda,13.735393550000001,-13.654784242248777,161,,Africa/Dakar,TUD,SN,Tambacounda,Tambacounda,,AP
-TUE,,Tupile,9.5725,-79.48722,0,,America/Panama,TUE,PA,Nombre de Dios,Colon,,AP
 TUF,LFOT,Val de Loire Airport,47.428333,0.7275,357,http://www.tours.aeroport.fr/index_en.php,Europe/Paris,TUF,FR,Parcay-Meslay,Centre,Departement d'Indre-et-Loire,AP
 TUG,RPUT,Tuguegarao Airport,17.643631300000003,121.73409169162102,70,,Asia/Manila,TUG,PH,Carig,Cagayan Valley,Province of Cagayan,AP
-TUH,,Arnold AFS,35.36667,-86.21667,0,,America/Chicago,THA,US,Tullahoma,Tennessee,Coffee County,AP
 TUI,OETR,Turaif Airport,31.69201315,38.73264882506025,2803,,Asia/Riyadh,TUI,SA,Turayf,Northern Borders,,AP
 TUJ,,Tum,5.833333,35.566666,4700,,Africa/Addis_Ababa,TUJ,ET,Bako,"Southern Nations, Nationalities, and People's Region",,AP
 TUK,OPTU,Turbat Airport,25.98209085,63.03028137910644,498,,Asia/Karachi,TUK,PK,Turbat,Balochistan,,AP
@@ -8319,7 +8164,6 @@ TWC,,Tumxuk Tangwangcheng Airport,39.885721450000005,79.23153844028876,0,,Asia/S
 TWD,K0S9,Port Townsend,48.11667,-122.76667,108,http://www.portofpt.com/airport.htm,America/Los_Angeles,TWD,US,Port Townsend,Washington,Jefferson County,AP
 TWE,AK49,Taylor,65.73333,-164.85,440,,America/Anchorage,TWE,US,,,,AP
 TWF,KTWF,Magic Valley Regional Airport,42.4817,-114.4877,4154,,America/Boise,TWF,US,Twin Falls,Idaho,Twin Falls County,AP
-TWH,,Two Harbors,33.4325701,-118.508601,0,,America/Los_Angeles,AVX,US,Avalon,California,Los Angeles County,AP
 TWN,,Tewantin,-26.422261,153.06349594526466,0,,Australia/Brisbane,TWN,AU,Noosaville,Queensland,Sunshine Coast,AP
 TWP,,Torwood,-17.3633003,143.75,0,,Australia/Brisbane,TWP,AU,,,,AP
 TWT,RPMN,Tawitawi,5.044958,119.74403,15,,Asia/Manila,TWT,PH,Bongao,Autonomous Region in Muslim Mindanao,Province of Tawi-Tawi,AP
@@ -8329,9 +8173,7 @@ TWZ,NZUK,Pukaki/Twizel,-44.234165,170.11722,1575,,Pacific/Auckland,MON,NZ,Pleasa
 TXC,UMIO,Balbasovo Air Base,54.44,30.296667,620,,Europe/Minsk,TXC,BY,Orsha,,,AP
 TXE,WITK,Rembele Airport,4.7229057,96.8491092260279,4648,,Asia/Jakarta,TXE,ID,Simpang Teritit,Aceh,,AP
 TXF,SNTF,Teixeira de Freitas Airport,-7.133333,-37.183334,344,,America/Bahia,TXF,BR,Teixeira,Paraiba,Teixeira,AP
-TXG,,Taichung,24.15,120.64611,0,,Asia/Taipei,TXG,TW,Taichung,Taiwan,Taichung City,AP
 TXK,KTXK,Texarkana Municipal Airport,33.45639,-93.98917,390,,America/Chicago,TXK,US,Texarkana,Arkansas,Miller County,AP
-TXL,EDDT,Tegel Airport,52.5568088,13.30375552174911,122,http://www.berlin-airport.de/en/travellers-txl/index.php,Europe/Berlin,BER,DE,Tegel,Berlin,,AP
 TXM,WAST,Teminabuan,-1.4453588499999999,132.0208113874629,141,,Asia/Jayapura,TXM,ID,Teminabuan,West Papua,,AP
 TXN,ZSTX,Huangshan Tunxi International Airport,29.73328205,118.25567849391369,0,,Asia/Shanghai,TXN,CN,Yiqi,Anhui Sheng,,AP
 TXR,YTNB,Tanbar,-25.8477993,141.9279938,344,,Australia/Brisbane,TXR,AU,,,,AP
@@ -8381,7 +8223,6 @@ UBR,WAJU,Ubrub,-3.67572165,140.88441053702942,1370,,Asia/Jayapura,UBR,ID,,,,AP
 UBS,KUBS,Lowndes County,33.466667,-88.38333,188,,America/Chicago,UBS,US,Columbus,Mississippi,Lowndes County,AP
 UBT,SDUB,Ubatuba,-23.441335600000002,-45.07459704874877,13,,America/Sao_Paulo,UBT,BR,Ubatuba,Sao Paulo,Ubatuba,AP
 UBU,YKAL,Kalumburu,-14.3,126.65,29,,Australia/Perth,UBU,AU,,,,AP
-UCA,,Oneida County,43.141388,-75.38028,0,,America/New_York,UCA,US,Clark Mills,New York,Oneida County,AP
 UCB,ZBUC,Ulanqab Jining Airport,41.1219377,113.1319445,0,,Asia/Shanghai,UCB,MN,Jining,Inner Mongolia,,AP
 UCC,NV11,Yucca Flat,37.0,-116.05,3919,,America/Los_Angeles,UCC,US,Beatty,Nevada,Nye County,AP
 UCE,4R7,Eunice,30.463455600000003,-92.42320287905048,42,,America/Chicago,UCE,US,Eunice,Louisiana,Saint Landry Parish,AP
@@ -8395,13 +8236,11 @@ UDE,,Volkel,51.666668,5.616667,0,,Europe/Amsterdam,UDE,NL,Uden,North Brabant,Gem
 UDI,SBUL,Uberlandia-Ten. Cel. Av. Cesar Bombonato Airport,-18.9,-48.233334,3094,,America/Sao_Paulo,UDI,BR,Uberlandia,Minas Gerais,Uberlandia,AP
 UDJ,UKLU,Uzhgorod,48.63582435,22.26068962869202,383,,Europe/Uzhgorod,UDJ,UA,Uzhhorod,Zakarpattia,Uzhgorodskiy Raion,AP
 UDN,LIPD,Airfield,46.033333,13.183333,305,,Europe/Rome,UDN,IT,Pasian di Prato,Friuli Venezia Giulia,Provincia di Udine,AP
-UDO,,Udomxay,19.133333,103.816666,0,,Asia/Vientiane,UDO,LA,Muong Xen,Nghe An,,AP
 UDR,VAUD,Maharana Pratap Airport,24.61747795,73.89536493575547,1684,http://www.airportsindia.org.in/allAirports/udaipur_airpo_gi.jsp,Asia/Kolkata,UDR,IN,Udaipur,Rajasthan,Udaipur,AP
 UEE,YQNS,Queenstown,-42.083332,145.55,867,,Australia/Hobart,UEE,AU,Queenstown,Tasmania,West Coast,AP
 UEL,FQQL,Quelimane Airport,-17.847221,36.865555,36,,Africa/Maputo,UEL,MZ,Quelimane,Zambezia,,AP
 UEN,USDU,Urengoy,65.96057339999999,78.43674503060257,56,,Asia/Yekaterinburg,UEN,RU,Urengoy,Yamalo-Nenetskiy Avtonomnyy Okrug,,AP
 UEO,ROKJ,Kume-jima Airport,26.365278,126.719444,23,,Asia/Tokyo,UEO,JP,Naha-shi,Okinawa,,AP
-UER,,Puertollano,38.7,-4.116667,0,,Europe/Madrid,UER,ES,Puertollano,Castille-La Mancha,Provincia de Ciudad Real,AP
 UES,KUES,Waukesha,43.039602200000004,-88.23488740524746,911,https://www.waukeshacounty.gov/airport/,America/Chicago,UES,US,Waukesha,Wisconsin,Waukesha County,AP
 UET,OPQT,Quetta Airport,30.2526982,66.93800061461184,5267,,Asia/Karachi,UET,PK,Kot Malik,Balochistan,,AP
 UFA,UWUU,Ufa International Airport,54.55435815,55.88220985059501,449,http://www.airportufa.ru/en/,Asia/Yekaterinburg,UFA,RU,Avdon,Bashkortostan,,AP
@@ -8446,10 +8285,8 @@ UKS,URFB,Belbek,44.6866456,33.56699649490146,344,,Europe/Simferopol,UKS,KX,Inker
 UKT,KUKT,Upper Bucks,40.433334,-75.35,526,http://www.bcaanet.org/quakertown.html,America/New_York,UKT,US,Quakertown,Pennsylvania,Bucks County,AP
 UKU,AYNU,Nuku,-3.683333,142.46666,870,,Pacific/Port_Moresby,UKU,PG,,,,AP
 UKX,UITT,Ust-Kut Airport,56.858894750000005,105.72207485831456,2188,,Asia/Irkutsk,UKX,RU,Ust'-Kut,Irkutsk,,AP
-UKY,,Kyoto,35.0082126,135.7726723,0,,Asia/Tokyo,UKY,JP,Kyoto,Kyoto,,AP
 ULA,SAWJ,San Julian,-49.316666,-67.666664,203,,America/Argentina/Rio_Gallegos,ULA,AR,San Julian,Santa Cruz,,AP
 ULB,NVSU,Ulei,-16.416668,168.33333,170,,Pacific/Efate,ULB,VU,Lakatoro,Malampa,,AP
-ULC,,Los Cerrillos,-33.489723,-70.694725,0,,America/Santiago,SCL,CL,Lo Prado,Santiago Metropolitan,Provincia de Santiago,AP
 ULD,FAUL,Ulundi,-28.3188641,31.417100515549492,1720,,Africa/Johannesburg,ULD,ZA,Ulundi,KwaZulu-Natal,Zululand District Municipality,AP
 ULE,,Sule,-4.933333,151.26666,100,,Pacific/Port_Moresby,ULE,PG,Kokopo,East New Britain,,AP
 ULG,ZMUL,Ulgit,48.966667,89.96667,5732,,Asia/Hovd,ULG,MN,OElgiy,Bayan-Olgiy,,AP
@@ -8471,7 +8308,6 @@ ULZ,ZMDN,Uliastai,47.7414683,96.8499229,5800,,Asia/Hovd,ULZ,MN,Uliastay,Dzabkhan
 UMA,MUMA,Punta De Maisi,20.2423436,-74.1490094,3,,America/Havana,UMA,CU,Maisi,Guantanamo,,AP
 UMB,,North Shore,53.376667,-167.8875,0,,America/Anchorage,UMB,US,,,,AP
 UMC,AYUC,Umba,-7.021325,145.96630039886003,5950,,Pacific/Port_Moresby,UMC,PG,,,,AP
-UMD,,Uummannaq,70.66889,-52.11778,0,,America/Godthab,UMD,GL,Uummannaq,Qaasuitsup,,AP
 UME,ESNU,Umea Airport,63.7903095,20.288655093670805,24,https://www.swedavia.com/umea/,Europe/Stockholm,UME,SE,Umea,Vaesterbotten,Umea Kommun,AP
 UMI,SPIL,Quincemil,-13.25,-70.666664,2047,,America/Lima,UMI,PE,Quince Mil,Cusco,Provincia de Quispicanchis,AP
 UMM,PAST,Summit,63.316666,-149.31667,2409,,America/Anchorage,UMM,US,Healy,Alaska,Denali Borough,AP
@@ -8490,15 +8326,12 @@ UNI,TVSU,Union Island,13.5,-61.0,16,,America/St_Vincent,UNI,VC,,,,AP
 UNK,PAUN,Unalakleet Airport,63.890888849999996,-160.8010690245273,27,,America/Anchorage,UNK,US,,,,AP
 UNN,VTSR,Ranong Airport,9.852778,98.629166,57,,Asia/Bangkok,UNN,TH,Ranong,Ranong,,AP
 UNR,ZMUH,Underkhaan,47.316666,110.666664,3410,,Asia/Ulaanbaatar,UNR,MN,Undurkhaan,Hentiy,,AP
-UNS,,Umnak,53.25,-168.33333,0,,America/Anchorage,UMB,US,Unalaska,Alaska,Aleutians West Census Area,AP
 UNT,EGPW,Baltasound,60.7475983,-0.8532495,0,,Europe/London,UNT,GB,,,,AP
 UNU,KUNU,Dodge County,58.3,-134.41667,934,http://www.co.dodge.wi.us/index.aspx?page=44,America/Chicago,UNU,US,Juneau,Alaska,Juneau City and Borough,AP
 UOA,NTTX,Mururoa Airstrip,-21.809443,-138.813055,7,,Pacific/Tahiti,UOA,PF,,,,AP
 UOL,WAMY,Buol,1.166667,121.433334,27,,Asia/Makassar,UOL,ID,Kali,Central Sulawesi,,AP
-UON,,Muong Sai,20.7,101.98333,0,,Asia/Vientiane,UON,LA,Muang Xay,Oudomxai,,AP
 UOS,KUOS,Franklin County,35.2047567,-85.8995529,1953,,America/Chicago,UOS,US,Sewanee,Tennessee,Franklin County,AP
 UOX,KUOX,University-Oxford,34.382689299999996,-89.53205882081014,452,http://airport.olemiss.edu/,America/Chicago,UOX,US,University,Mississippi,Lafayette County,AP
-UPA,,Punta Alegre,22.383333,-78.816666,0,,America/Havana,UPA,CU,Chambas,Ciego de Avila,,AP
 UPB,MUPB,Playa Baracoa,23.028541099999998,-82.57921215824531,102,,America/Havana,UPB,CU,Bauta,Artemisa,,AP
 UPG,WAAA,Sultan Hasanuddin International Airport,-5.07668215,119.55303856777952,47,,Asia/Makassar,UPG,ID,Makassar,South Sulawesi,,AP
 UPL,MRUP,Upala,10.783333,-85.03333,184,https://www.google.com/url?sa=t&source=web&rct=j&url=https://m.facebook.com/Aerodromo-de-Upala-913599102022097/&ved=0ahUKEwjajLC,America/Costa_Rica,UPL,CR,Bijagua,Alajuela,,AP
@@ -8506,7 +8339,6 @@ UPN,MMPN,Licenciado y General Ignacio Lopez Rayon Airport,19.411112,-102.04722,5
 UPP,PHUP,Upolu Point,20.265102,-155.85961196910415,96,,Pacific/Honolulu,UPP,US,Hawi,Hawaii,Hawaii County,AP
 UPR,AYUR,Upiara,-8.533333,142.63333,52,,Pacific/Port_Moresby,UPR,PG,,,,AP
 UPV,EGDJ,Upavon,51.287953099999996,-1.783640664251557,574,,Europe/London,UPV,GB,Rushall,England,Wiltshire,AP
-UQE,,Queen,58.876667,-158.43167,0,,America/Anchorage,UQE,US,,,,AP
 URA,UARR,Uralsk Airport,51.15188705,51.541522050576205,125,,Asia/Oral,URA,KZ,Oral,Batys Qazaqstan,,AP
 URB,,Ernesto Pochler,-20.783333,-51.566666,1169,,America/Sao_Paulo,URB,BR,Castilho,Sao Paulo,Castilho,AP
 URC,ZWWW,Urumqi Diwopu International Airport,43.903818349999995,87.46801888787405,2125,,Asia/Shanghai,URC,CN,,,,AP
@@ -8547,12 +8379,10 @@ UTG,FXQG,Quthing,-30.5,27.6,5350,,Africa/Maseru,UTG,LS,Quthing,Quthing,,AP
 UTH,VTUD,Udon Thani International Airport,17.3867791,102.7775596,579,http://www.udonthaniairport.com/,Asia/Bangkok,UTH,TH,Udon Thani,Changwat Udon Thani,,AP
 UTI,EFUT,Utti,60.8968577,26.9338175,339,,Europe/Helsinki,UTI,FI,Kouvola,Kymenlaakso,Kouvola,AP
 UTK,K03N,Utirik Island,11.2223226,169.85190447841075,4,,Pacific/Majuro,UTK,MH,Utrik,Utrik Atoll,,AP
-UTL,,Torremolinos,36.63333,-4.5,0,,Europe/Madrid,UTL,ES,Torremolinos,Andalusia,Provincia de Malaga,AP
 UTM,KUTA,Tunica Municipalcipal Airport,34.667694,-90.36767,194,http://tunicaairport.com/,America/Chicago,UTM,US,Tunica,Mississippi,Tunica County,AP
 UTN,FAUP,Upington Airport,-28.402504,21.258329003972364,2782,,Africa/Johannesburg,UTN,ZA,Upington,Northern Cape,Siyanda District Municipality,AP
 UTO,PAIM,Indian Mountain AFS,65.99333,-153.70166,1273,,America/Anchorage,UTO,US,,,,AP
 UTP,VTBU,Utapao Airport,12.683333,101.01667,42,http://www.utapao.com/,Asia/Bangkok,UTP,TH,Ban Chang,Rayong,,AP
-UTR,,Uttaradit,17.6735746,100.2334897,0,,Asia/Bangkok,UTR,TH,Uttaradit,Uttaradit,,AP
 UTS,UUYX,Ust-Tsilma,65.43961494999999,52.199675531796856,262,,Europe/Moscow,UTS,RU,Ust-Tsilma,Komi Republic,,AP
 UTT,FAUT,Umtata Airport,-31.583332,28.783333,2400,,Africa/Johannesburg,UTT,ZA,Mthatha,Eastern Cape,OR Tambo District Municipality,AP
 UTU,,Ustupo,9.666667,-78.833336,9,,America/Panama,UTU,PA,El Porvenir,Guna Yala,,AP
@@ -8574,7 +8404,6 @@ UYL,HSNN,Nyala,12.071667,24.894722,2185,,Africa/Khartoum,UYL,SD,Nyala,Southern D
 UYN,ZLYL,Yulin Yuyang Airport,38.274155,109.73038,3510,http://www.cwag-yl.com/,Asia/Shanghai,UYN,CN,Yulin,Shaanxi,,AP
 UYU,SLUY,Uyuni,-20.44139465,-66.85327806874254,12030,,America/La_Paz,UYU,BO,Uyuni,Potosi,,AP
 UZC,,Uzice-Ponikve,43.8993239,19.682303078044633,2988,,Europe/Belgrade,UZC,RS,Bajina Basta,Central Serbia,Zlatiborski Okrug,AP
-UZH,,Unayzah,26.1,43.933334,2145,,Asia/Riyadh,UZH,SA,Unaizah,Al-Qassim,,AP
 UZM,,Hope Bay,68.15850165,-106.61625764888016,65,,America/Cambridge_Bay,UZM,CA,,,,AP
 UZR,UASU,Urzhar Airport,47.0891041,81.6558493669576,1614,,Asia/Almaty,UZR,KZ,Urzhar,East Kazakhstan,,AP
 UZU,SATU,Curuzu Cuatia,-29.778889,-58.095554,213,,America/Argentina/Cordoba,UZU,AR,Curuzu Cuatia,Corrientes,,AP
@@ -8602,13 +8431,11 @@ VAW,ENSS,Vardoe Airport,70.35472,31.045555,0,https://avinor.no/en/airport/vardo-
 VBA,VYAN,Ann,19.7704774,94.02635921340655,29,,Asia/Rangoon,VBA,MM,Minbu,Magway,,AP
 VBC,,Mandalay Chanmyathazi Airport,21.9368685,96.08892957340962,157,,Asia/Yangon,VBC,MM,Mandalay,Mandalay,,AP
 VBG,KVBG,Vandenberg AFB,34.63333,-120.46667,52,,America/Los_Angeles,LPC,US,Lompoc,California,Santa Barbara County,AP
-VBM,,Blue Mountain,57.8575,-157.08667,131,,America/Anchorage,VBM,US,,,,AP
 VBP,VYBP,Bokpyin Airport,11.14878895,98.7363448190028,65,,Asia/Rangoon,VBP,MM,Tha Sae,Chumphon,,AP
 VBS,LIPO,Montichiari Airport,45.4279922,10.328465676993805,305,http://www.aeroportobrescia.it/en/business_t6/,Europe/Rome,VRN,IT,Vighizzolo,Lombardy,Provincia di Brescia,AP
 VBV,NFVB,Vanuabalavu,-17.233334,-178.95,226,,Pacific/Fiji,VBV,FJ,Alo,Circonscription d'Alo,,AP
 VBY,ESSV,Visby Airport,57.66543765,18.34705855149554,78,https://www.swedavia.com/visby/,Europe/Stockholm,VBY,SE,Visby,Gotland,Gotland,AP
 VCA,VVCT,Can Tho Airport,10.047222,105.76639,19,,Asia/Ho_Chi_Minh,VCA,VN,Can Tho,Can Tho,,AP
-VCB,,View Cove,55.083332,-133.01666,78,,America/Anchorage,VCB,US,,,,AP
 VCC,SNEE,New Vacaria Airport,-28.431944,-51.022778,2975,,America/Sao_Paulo,VCC,BR,Vacaria,,,AP
 VCD,YVRD,Victoria River Downs,-16.4021244,131.0049744,285,,Australia/Darwin,VCD,AU,Katherine,Northern Territory,Katherine,AP
 VCE,LIPZ,Venice Marco Polo Airport,45.50353855,12.342579681064803,19,http://www.veniceairport.com/core/index.jsp?_requestid=37300&language=en,Europe/Rome,VCE,IT,Tessera,Veneto,Provincia di Venezia,AP
@@ -8631,7 +8458,6 @@ VDO,VVVD,Van Don,21.1177533,107.41680680237144,26,http://www.vandon-airport.com/
 VDP,SVVP,Valle De Pascua,9.22178785,-65.99245012577492,541,,America/Caracas,VDP,VE,Valle de La Pascua,Guarico,Municipio Leonardo Infante,AP
 VDR,SAOD,Villa Dolores,-31.9438459,-65.1479642056974,1801,,America/Argentina/Cordoba,VDR,AR,Villa Dolores,Cordoba,,AP
 VDS,ENVD,Vadso Airport,70.0649621,29.846431239541218,91,https://avinor.no/en/airport/vadso-airport/,Europe/Oslo,VDS,NO,Vadso,Finnmark Fylke,Vadso,AP
-VDU,,Tom O'Connor Oilfield,28.3,-97.28333,26,,America/Chicago,RFG,US,Refugio,Texas,Refugio County,AP
 VDY,VOJV,Jindal,15.1743056,76.6334746,1656,,Asia/Kolkata,VDY,IN,Sandur,Karnataka,Bellary,AP
 VDZ,PAVD,Valdez Municipal Airport,61.1325,-146.23889,65,,America/Anchorage,VDZ,US,Valdez,Alaska,Valdez-Cordova Census Area,AP
 VEE,PAVE,Venetie,67.0086975,-146.3659973,636,,America/Anchorage,VEE,US,Eielson Air Force Base,Alaska,Fairbanks North Star Borough,AP
@@ -8645,7 +8471,6 @@ VEY,BIVM,Vestmannaeyjar,63.42546055,-20.278156148378084,0,,Atlantic/Reykjavik,VE
 VFA,FVFA,Victoria Falls Airport,-18.093056,25.840279,3503,,Africa/Harare,VFA,ZW,Victoria Falls,Matabeleland North,Hwange District,AP
 VGA,VOBZ,Vijayawada Airport,16.52364325,80.79127464592091,59,https://www.aai.aero/en/airports/vijayawada,Asia/Kolkata,VGA,IN,Gannavaram,Andhra Pradesh,Krishna,AP
 VGD,ULWW,Vologda Airport,59.28111415,39.939323172224164,377,,Europe/Moscow,VGD,RU,Vologda,Vologda,,AP
-VGG,,Vangrieng,62.53,11.07,2155,,Asia/Vientiane,VGG,LA,Tolga,Hedmark,Tolga,AP
 VGO,LEVX,Vigo Airport,42.232922450000004,-8.626166079129476,833,,Europe/Madrid,VGO,ES,Redondela,Galicia,Provincia de Pontevedra,AP
 VGS,,General Villegas,-35.083332,-63.0,413,,America/Argentina/Buenos_Aires,VGS,AR,General Villegas,Buenos Aires,,AP
 VGT,KVGT,North Air Terminal,36.09667,-115.16889,2125,http://www.vgt.aero/index.html,America/Los_Angeles,LAS,US,Paradise,Nevada,Clark County,AP
@@ -8658,14 +8483,11 @@ VHY,LFLV,Charmeil,46.1702041,3.4031454015741196,777,,Europe/Paris,VHY,FR,Creuzie
 VHZ,NTUV,Vahitahi,-18.583332,-138.83333,0,,Pacific/Tahiti,VHZ,PF,,,,AP
 VIA,SSVI,Vienna,-27.008333,-51.136112,2588,,America/Sao_Paulo,VIA,BR,Videira,Santa Catarina,Videira,AP
 VIB,,Villa Constitucion,25.058332,-111.7,160,,America/Mazatlan,VIB,MX,Ciudad Constitucion,Baja California Sur,,AP
-VIC,LIPT,Trissino,45.55,11.55,85,,Europe/Rome,VIC,IT,,,,AP
 VIE,LOWW,Vienna International Airport,48.10499675,16.5848987032657,561,http://www.viennaairport.com/en/,Europe/Vienna,VIE,AT,Fischamend Dorf,Lower Austria,Politischer Bezirk Wien-Umgebung,AP
-VIF,,Vieste,41.885277,16.176945,29,,Europe/Rome,VIF,IT,Vieste,Apulia,Provincia di Foggia,AP
 VIG,SVVG,El Vigia,8.62391785,-71.67132508302207,216,,America/Caracas,VIG,VE,El Vigia,Merida,Municipio Alberto Adriani,AP
 VIH,KVIH,Rolla National,38.1278213,-91.7696061,1115,http://www.rollacity.org/airport/airport.shtml,America/Chicago,VIH,US,Belle,Missouri,Maries County,AP
 VII,VVVH,Vinh Airport,18.7,105.63333,42,,Asia/Ho_Chi_Minh,VII,VN,Hung Nguyen,Nghe An,,AP
 VIJ,TUPW,Virgin Gorda Airport,18.4466072,-64.4279001888192,36,,America/Tortola,VIJ,VG,Tortola,,,AP
-VIK,,Airstrip,69.68,-146.9,636,,America/Anchorage,VIK,US,,,,AP
 VIL,GMMH,Dakhla Airport,23.724744049999998,-15.927466161127052,42,,Africa/Casablanca,VIL,MA,Dakhla,Oued Ed-Dahab-Lagouira,,AP
 VIN,UKWW,Havryshivka Vinnytsia International Airport,49.233334,28.483334,793,,Europe/Kiev,VIN,UA,Vinnytsya,Vinnyts'ka,,AP
 VIP,LSMP,PAYERNE Airport,46.843333,6.915,1460,,Europe/Zurich,VIP,CH,Payerne,,,AP
@@ -8685,7 +8507,6 @@ VKO,UUWW,Vnukovo Airport,55.5995278,37.27357516712458,662,http://www.vnukovo.ru/
 VKS,KVKS,Vicksburg,32.35,-90.85,331,http://www.vicksburg.org/departments/airport,America/Chicago,VKS,US,Vicksburg,Mississippi,Warren County,AP
 VKT,UUYW,Vorkuta Airport,67.48792929999999,64.00333895184659,551,,Europe/Moscow,VKT,RU,Vorkuta,Komi Republic,,AP
 VKV,ULAH,Vaskovo Airport,64.441667,40.421667,82,,Europe/Moscow,VKV,RU,Arkhangelsk,,,AP
-VKW,,West Kavik,69.76667,-146.91667,666,,America/Anchorage,VKW,US,,,,AP
 VLA,KVLA,Vandalia,38.966667,-89.1,521,,America/Chicago,VLA,US,Vandalia,Illinois,Fayette County,AP
 VLC,LEVC,Valencia Airport,39.4878647,-0.481209186098332,180,,Europe/Madrid,VLC,ES,,,,AP
 VLD,KVLD,Valdosta Regional Airport,30.77831025,-83.2780341085929,167,,America/New_York,VLD,US,Valdosta,Georgia,Lowndes County,AP
@@ -8696,7 +8517,6 @@ VLK,URRQ,Volgodonsk,47.6788908,42.07608291596857,232,,Europe/Moscow,VLK,RU,Tsiml
 VLL,LEVD,Valladolid Airport,41.706834349999994,-4.854374275220002,2772,,Europe/Madrid,VLL,ES,Villanubla,Castille and Leon,Provincia de Valladolid,AP
 VLM,SLVM,Villamontes,-21.25,-63.5,1410,,America/La_Paz,VLM,BO,Villamontes,Tarija,,AP
 VLN,SVVA,Arturo Michelena International Airport,10.151676850000001,-67.92881547478783,1433,,America/Caracas,VLN,VE,Los Guayos,Carabobo,Municipio Los Guayos,AP
-VLO,,Stolport,38.11667,-122.23333,88,,America/Los_Angeles,VLO,US,Vallejo,California,Solano County,AP
 VLP,SWVC,Vila Rica,-9.981114550000001,-51.14049738118665,813,,America/Cuiaba,VLP,BR,Conceicao do Araguaia,Para,Conceicao Do Araguaia,AP
 VLR,SCLL,Vallenar,-28.596016,-70.75508240859287,1771,,America/Santiago,VLR,CL,Vallenar,Atacama,Provincia de Huasco,AP
 VLS,NVSV,Valesdir,-16.7961006,168.177002,55,,Pacific/Efate,VLS,VU,Port-Vila,Shefa,,AP
@@ -8710,7 +8530,6 @@ VNA,VLSV,Saravane,15.7112708,106.4156619,610,,Asia/Vientiane,VNA,LA,Salavan,Sala
 VNC,KVNC,Venice Municipalcipal,27.066668,-82.433334,45,http://www.venicegov.com/Municipal_links/Airport/airport.asp,America/New_York,VNC,US,South Venice,Florida,Sarasota County,AP
 VND,FMSU,Vangaindrano,-23.350713,47.5818934,39,,Indian/Antananarivo,VND,MG,Vangaindrano,Atsimo-Atsinanana,,AP
 VNE,LFRV,Meucon,47.65,-2.766667,75,,Europe/Paris,VNE,FR,Vannes,Brittany,Departement du Morbihan,AP
-VNG,,Viengxay,18.933332,102.5,1505,,Asia/Vientiane,VNG,LA,Vangviang,Vientiane,,AP
 VNO,EYVI,Vilnius International Airport,54.63483615,25.290314330439507,590,http://www.vilnius-airport.lt/en/,Europe/Vilnius,VNO,LT,Naujamiestis,Vilnius County,,AP
 VNR,YVRS,Vanrook,-16.866667,141.91667,85,,Australia/Brisbane,VNR,AU,,,,AP
 VNS,VEBN,Lal Bahadur Shastri International Airport,25.4509975,82.86360523595738,269,,Asia/Kolkata,VNS,IN,Baragaon,Uttar Pradesh,Varanasi,AP
@@ -8744,17 +8563,13 @@ VRN,LIPX,Verona Villafranca Airport,45.39717245,10.885895928972548,216,http://ww
 VRO,MUKW,Kawama,23.133333,-81.3,13,,America/Havana,VRO,CU,Varadero,Matanzas,,AP
 VRS,3VS,Versailles,38.433334,-92.85,964,,America/Chicago,VRS,US,Versailles,Missouri,Morgan County,AP
 VRU,FAVB,Vryburg,-26.916668,24.75,3884,,Africa/Johannesburg,VRU,ZA,Vryburg,North-West,Dr Ruth Segomotsi Mompati District Municipality,AP
-VRY,,Stolport (Not operational),67.666664,12.683333,16,,Europe/Oslo,VRY,NO,Sorland,Nordland,Vaeroy,AP
 VRZ,SSOL,Lavras Airport,-21.2406,-44.9639,3156,,America/Sao_Paulo,VRZ,BR,Lavras,,,AP
 VSA,MMVA,Carlos Rovirosa Perez International Airport,17.9952401,-92.81879817289919,19,,America/Mexico_City,VSA,MX,El Bajio,Tabasco,Centro,AP
 VSE,LPVZ,Viseu Airport,40.65,-7.916667,1643,,Europe/Lisbon,VSE,PT,Viseu,Viseu,Viseu,AP
 VSF,KVSF,State,42.11667,-72.583336,193,,America/New_York,VSF,US,Springfield,Massachusetts,Hampden County,AP
 VSG,UKCW,Lugansk,48.566666,39.333332,219,,Europe/Kiev,VSG,UA,Luhansk,Luhansk,,AP
-VSK,,Vista Field,46.21861,-119.212546,515,,America/Los_Angeles,VSK,US,Kennewick,Washington,Benton County,AP
-VSO,,Phuoclong,9.433333,105.46667,36,,Asia/Ho_Chi_Minh,VSO,VN,Thi Tran Phuoc Long,Bac Lieu,,AP
 VST,ESOW,Vasteras/Hasslo Airport,59.58917,16.630556,78,,Europe/Stockholm,STO,SE,Vasteras,Vaestmanland,Vasteras,AP
 VSV,VISV,Shravasti Airport,27.503056,82.026944,366,,Asia/Kolkata,VSV,IN,Shravasti,Uttar Pradesh,,AP
-VTA,,Victoria,14.95,-87.4,1253,,America/Tegucigalpa,VTA,HN,Las Vegas,Yoro,,AP
 VTB,UMII,Vitebsk,55.13333,30.366667,623,,Europe/Minsk,VTB,BY,Vitebsk,Vitebsk,,AP
 VTE,VLVT,Wattay International Airport,17.9866469,102.56389705740517,501,http://www.vientianeairport.com/,Asia/Vientiane,VTE,LA,Si Chiang Mai,Nong Khai,,AP
 VTF,NFVL,Vatulele,-18.512366,177.63872588965222,29,,Pacific/Fiji,VTF,FJ,Nadi,Western,,AP
@@ -8793,7 +8608,6 @@ WAJ,AYWF,Wawoi Falls,-7.8,143.26666,0,,Pacific/Port_Moresby,WAJ,PG,,,,AP
 WAK,FMSZ,Ankazoabo,-22.2988757,44.5328871,1387,,Indian/Antananarivo,WAK,MG,Ankazoabo,Atsimo-Andrefana,,AP
 WAL,KWAL,Wallops Flight Center,37.933334,-75.38333,0,,America/New_York,WAL,US,Chincoteague,Virginia,Accomack County,AP
 WAM,FMMZ,Ambatondrazaka,-17.7953922,48.4424785,2496,,Indian/Antananarivo,WAM,MG,Ambatondrazaka,Alaotra Mangoro,,AP
-WAN,,Waverney,-25.3566422,141.9251849,570,,Australia/Brisbane,WAN,AU,,,,AP
 WAO,AYWB,Wabo,-7.495086,144.8243,72,,Pacific/Port_Moresby,WAO,PG,Ihu,Gulf,Kikori,AP
 WAP,SCAP,Alto Palena,-43.611506000000006,-71.80569953439687,813,http://angelesflying.com/aboutus.html,America/Santiago,WAP,CL,Palena,Los Lagos,Provincia de Palena,AP
 WAQ,FMMG,Antsalova,-18.6994859,44.6160405,524,,Indian/Antananarivo,WAQ,MG,,,,AP
@@ -8811,10 +8625,8 @@ WBC,AYWJ,Wapolu,-9.316667,150.35,32,,Pacific/Port_Moresby,WBC,PG,,,,AP
 WBD,FMNF,Befandriana,-15.2074248,48.4824574,839,,Indian/Antananarivo,WBD,MG,,,,AP
 WBE,FMNB,Bealanana,-14.5400804,48.6897102,3651,,Indian/Antananarivo,WBE,MG,Bealanana,Sofia,,AP
 WBG,ETNS,Schleswig-jagel,54.46404005,9.519220361389436,36,,Europe/Berlin,WBG,DE,Jagel,Schleswig-Holstein,,AP
-WBI,,Broker Inn,40.016666,-105.28333,5370,,America/Denver,WBU,US,,,,AP
 WBK,,Community,44.244801,-84.179802,849,http://www.westbranch.com/airport.pdf,America/Detroit,WBK,US,West Branch,Michigan,Ogemaw County,AP
 WBM,AYWD,Wapenamanda Airport,-5.635423599999999,143.8922603983255,5889,,Pacific/Port_Moresby,WBM,PG,,,,AP
-WBN,,Cummings Park,42.466667,-71.15,88,,America/New_York,WBN,US,Woburn,Massachusetts,Middlesex County,AP
 WBO,FMSB,Beroroha,-21.6,45.13333,879,,Indian/Antananarivo,WBO,MG,,,,AP
 WBQ,PAWB,Beaver,66.3613889,-147.4011111,354,,America/Anchorage,WBQ,US,Fairbanks,Alaska,Fairbanks North Star Borough,AP
 WBR,KRQB,Big Rapids,43.72222695,-85.49839607843418,908,,America/Detroit,WBR,US,Big Rapids,Michigan,Mecosta County,AP
@@ -8832,7 +8644,6 @@ WDI,YWND,Wondai,-26.333332,151.81667,1335,,Australia/Brisbane,WDI,AU,Wondai,Quee
 WDN,90WA,Waldron Island,48.71244645,-123.01864572666307,101,,America/Los_Angeles,WDN,US,,,,AP
 WDR,KWDR,Winder,33.9817836,-83.66526062716945,898,http://www.wdrairport.com/,America/New_York,WDR,US,Winder,Georgia,Barrow County,AP
 WDS,ZHSY,Shiyan Wudangshan Airport,37.913056,114.591667,164,,Asia/Shanghai,WDS,CN,Luancheng,Hebei,,AP
-WDY,,Kodiak Fss,57.783333,-152.4,118,,America/Anchorage,ADQ,US,Kodiak,Alaska,Kodiak Island Borough,AP
 WEA,KWEA,Parker County,32.766666,-97.8,1003,,America/Chicago,WEA,US,Weatherford,Texas,Parker County,AP
 WED,,Wedau,-10.09498645,150.08359419886068,59,,Pacific/Port_Moresby,WED,PG,,,,AP
 WEF,ZSWF,Weifang Airport,36.647181450000005,119.11501057347209,141,,Asia/Shanghai,WEF,CN,Weifang,Shandong Sheng,,AP
@@ -8848,7 +8659,6 @@ WFD,,Woodford,53.338055,-2.148889,308,,Europe/London,WFD,GB,Adlington,England,Ch
 WFI,FMSF,Fianarantsoa,-21.466667,47.083332,3917,,Indian/Antananarivo,WFI,MG,Fianarantsoa,Upper Matsiatra,,AP
 WFK,KFVE,Frenchville,47.35,-68.333336,682,,America/New_York,WFK,US,Madawaska,Maine,Aroostook County,AP
 WGA,YSWG,Wagga Wagga Airport,-35.16567315,147.46300325635022,669,http://www.wagga.nsw.gov.au/www/html/271-airport.asp,Australia/Sydney,WGA,AU,Forest Hill,New South Wales,Wagga Wagga,AP
-WGB,,Bahawalnagar,30.0,73.25,508,,Asia/Karachi,WGB,PK,Bahawalnagar,Punjab,,AP
 WGC,VOWA,Warangal,17.9140552,79.6036086,958,http://aai.aero/allAirports/warrangal.jsp,Asia/Kolkata,WGC,IN,Warangal,Telangana,Warangal,AP
 WGE,YWLG,Walgett,-30.0321528,148.12542342678233,439,,Australia/Sydney,WGE,AU,Lightning Ridge,New South Wales,Walgett,AP
 WGN,ZGSY,Waitangi,-36.266945,174.1,131,,Pacific/Auckland,WGN,NZ,Dargaville,Northland,Kaipara District,AP
@@ -8861,7 +8671,6 @@ WHA,,Wuhu Xuanzhou Airport,31.10427305,118.66472096651194,68,,Asia/Shanghai,WHA,
 WHB,,Eliwana Airport,-22.4306826,116.8863515,1555,,Australia/Perth,WHB,AU,Eliwana,Western Australia,,AP
 WHD,,SPB,55.916668,-130.08333,2201,,America/Sitka,WHD,US,,,,AP
 WHF,HSSW,Wadi Halfa,21.75,31.5,830,,Africa/Khartoum,WHF,SD,Abu Sunbul,Aswan,,AP
-WHH,,Hiltons Har H,40.030556,-105.23472,5242,,America/Denver,WBU,US,,,,AP
 WHK,NZWK,Whakatane Airport,-37.92149575,176.9146790652377,29,,Pacific/Auckland,WHK,NZ,Whakatane,Bay of Plenty,Whakatane District,AP
 WHL,,Welshpool,-38.68889,146.45,32,,Australia/Melbourne,WHL,AU,Morwell,Victoria,Latrobe,AP
 WHN,,Wuhan Hannan General Airport,30.251781,114.055361,82,,Asia/Shanghai,WHN,CN,Wuhan,,,AP
@@ -8890,11 +8699,9 @@ WKF,FAWK,Waterkloof AFB,-30.316668,25.3,4311,,Africa/Johannesburg,PRY,ZA,Colesbe
 WKI,FVWT,Hwange,-18.3623096,26.52106461017609,2463,,Africa/Harare,WKI,ZW,Hwange,Matabeleland North,Hwange District,AP
 WKJ,RJCW,Hokkaido Airport,45.39943,141.7974,52,,Asia/Tokyo,WKJ,JP,Makubetsu,Hokkaido,,AP
 WKK,5A8,Aleknagik,59.2824,-158.6181,29,,America/Anchorage,WKK,US,,,,AP
-WKL,,Waikoloa Airport,19.85,-156.33333,0,,Pacific/Honolulu,WKL,US,Kalaoa,Hawaii,Hawaii County,AP
 WKN,AYWQ,Wakunai,-5.8604274499999995,155.22238548987872,22,,Pacific/Port_Moresby,WKN,PG,Arawa,Bougainville,,AP
 WKR,MYAW,Walker's Cay,27.259706,-78.4014295,19,,America/Nassau,WKR,BS,High Rock,East Grand Bahama,,AP
 WLA,YWAL,Wallal,-19.776862649999998,120.65183811802402,29,,Australia/Perth,WLA,AU,,,,AP
-WLB,,Labouchere Bay,56.291668,-133.65834,0,,America/Sitka,WLB,US,,,,AP
 WLC,YWCH,Walcha,-30.983334,151.6,3448,,Australia/Sydney,WLC,AU,Enmore,New South Wales,Armidale Dumaresq,AP
 WLD,KWLD,Arkansas City,37.166943,-97.05028,1158,,America/Chicago,WLD,US,Winfield,Kansas,Cowley County,AP
 WLE,YMLS,Miles Airport,-26.809167,150.165,958,,Australia/Brisbane,WLE,AU,Westcourt,Queensland,Western Downs,AP
@@ -8902,8 +8709,6 @@ WLG,NZWN,Wellington International Airport,-41.32691975,174.8077029634527,19,http
 WLH,NVSW,Walaha,-15.4111246,167.69118229180754,101,,Pacific/Efate,WLH,VU,Saratamata,Penama,,AP
 WLK,PASK,Selawik Airport,66.6003169,-159.9946695,26,,America/Anchorage,WLK,US,,,,AP
 WLL,YWOR,Wollogorang,-17.616667,137.91667,918,,Australia/Darwin,WLL,AU,Mount Isa,Queensland,Mount Isa,AP
-WLM,,Waltham,42.385277,-71.25139,164,,America/New_York,WLM,US,Waltham,Massachusetts,Middlesex County,AP
-WLN,,Little Naukati,55.8521547,-133.2292064,0,,America/Sitka,WLN,US,,,,AP
 WLO,YWTL,Waterloo,-16.6299992,129.3200073,406,,Australia/Darwin,WLO,AU,,,,AP
 WLP,YANG,West Angelas Airport,-23.1356,118.7072,2257,,Australia/Perth,WLP,AU,Tom Price,Western Australia,Ashburton,AP
 WLR,13Z,Loring,55.666668,-131.66667,1876,,America/Sitka,WLR,US,,,,AP
@@ -8926,7 +8731,6 @@ WMT,ZUMT,Zunyi Maotai Airport,27.956382650000002,106.43593156796578,4019,,Asia/S
 WMV,,Madirovalo,-16.45,46.566666,170,,Indian/Antananarivo,WMV,MG,Ambato Boeny,Boeny,,AP
 WMX,WAJW,Wamena Airport,-4.09665775,138.95220458580468,5403,,Asia/Jayapura,WMX,ID,Wurigelebur,Papua,,AP
 WNA,PANA,Napakiak Sea Plane Base,60.7,-162.11667,0,,America/Anchorage,WNA,US,,,,AP
-WNC,,Naukati Bay SPB,55.854168,-133.225,0,,America/Anchorage,WNC,US,,,,AP
 WND,YWDA,Windarra,-28.266666,121.833336,1387,,Australia/Perth,WND,AU,,,,AP
 WNE,,Wora Na Ye,-1.35,9.333333,16,,Africa/Libreville,WNE,GA,Omboue,Ogooue-Maritime,,AP
 WNH,ZPWS,Wenshan Puzhehei Airport,23.374907,104.24256,4179,,Asia/Shanghai,WNH,CN,Wenshan City,Yunnan,Wenshan Zhuangzu Miaozu Zizhizhou,AP
@@ -8938,13 +8742,11 @@ WNS,OPNH,Nawabshah,26.21551985,68.38923334846139,72,,Asia/Karachi,WNS,PK,Nawabsh
 WNU,AYWH,Wanuma,-4.9,145.31667,1938,,Pacific/Port_Moresby,WNU,PG,Madang,Madang,,AP
 WNZ,ZSWZ,Wenzhou Longwan International Airport,27.908789300000002,120.84686367619172,32,,Asia/Shanghai,WNZ,CN,Qidu,Zhejiang Sheng,,AP
 WOA,AYWO,Wonenara,-6.79699265,145.89236349345992,4993,,Pacific/Port_Moresby,WOA,PG,,,,AP
-WOD,,Wood River,38.86667,-90.083336,429,,America/Anchorage,WOD,US,Wood River,Illinois,Madison County,AP
 WOE,EHWO,Woensdrecht,51.443396899999996,4.336315574532236,32,http://www.defensie.nl/luchtmacht/luchtmachtbases/woensdrecht/,Europe/Amsterdam,WOE,NL,Woensdrecht,North Brabant,Gemeente Woensdrecht,AP
 WOG,,Woodgreen Airport,-22.5,134.25,1866,,Australia/Darwin,WOG,AU,,,,AP
 WOK,,Wonken,5.25,-61.733334,3192,,America/Caracas,WOK,VE,Santa Elena de Uairen,Bolivar,Municipio Gran Sabana,AP
 WOL,YSHL,Wollongong,-34.566666,150.78334,19,,Australia/Sydney,WOL,AU,Albion Park Rail,New South Wales,Shellharbour,AP
 WON,YWDL,Wondoola,-18.5750008,140.8919983,124,,Australia/Brisbane,WON,AU,,,,AP
-WOO,,Woodchopper,65.333336,-143.53334,1374,,America/Anchorage,WOO,US,,,,AP
 WOR,,Moramba,-14.883333,47.283333,0,,Indian/Antananarivo,WOR,MG,,,,AP
 WOS,ZKWS,Wonsan,50.216667,-126.61667,544,,Asia/Pyongyang,WOS,KP,,,,AP
 WOT,RCWA,Wonan,23.416668,119.5,0,http://www.mkport.gov.tw/English/index.htm,Asia/Taipei,WOT,TW,Ma-kung,Taiwan,Penghu,AP
@@ -8977,7 +8779,7 @@ WSD,KWSD,Condron AAF,32.38333,-106.48333,4291,,America/Denver,WSD,US,White Sands
 WSF,,Sarichef,54.5861889,-164.902081,236,,America/Anchorage,WSF,US,Akutan,Alaska,Aleutians East Borough,AP
 WSG,KAFJ,County,40.166668,-80.25,1040,,America/New_York,WSG,US,Washington,Pennsylvania,Washington County,AP
 WSH,KHWV,Brookhaven,40.75,-72.833336,0,,America/New_York,WSH,US,Mastic Beach,New York,Suffolk County,AP
-WSJ,,San Juan SPB,57.73111,-153.31833,42,,America/Anchorage,WSJ,US,Kodiak Station,Alaska,Kodiak Island Borough,AP
+WSI,YSWS,Western Sydney International (Nancy Bird Walton) Airport,-33.88806,150.71472,262,,Australia/Sydney,WSI,AU,Sydney,New South Wales,,AP
 WSK,ZUWS,Chongqing Wushan Airport,31.07157155,109.71336937776792,5800,,Asia/Shanghai,WSK,CN,Quchi,Chongqing Shi,,AP
 WSM,WSM,Wiseman,67.4059294,-150.1190072,1286,,America/Anchorage,WSM,US,Nuiqsut,Alaska,North Slope Borough,AP
 WSN,PFWS,South Naknek,58.6995042,-156.99996786405472,85,,America/Anchorage,WSN,US,Dillingham,Alaska,Dillingham Census Area,AP
@@ -8992,7 +8794,6 @@ WSY,YWHI,Whitsunday Airstrip,-20.502777,148.75278,0,http://www.whitsundayairport
 WSZ,NZWS,Westport Airport,-41.74002,171.57858,22,,Pacific/Auckland,WSZ,NZ,Westport,West Coast,Buller District,AP
 WTA,FMMU,Tambohorano,-17.4761009,43.9728012,36,,Indian/Antananarivo,WTA,MG,Maintirano,Melaky,,AP
 WTB,YBWW,Toowoomba Wellcamp Airport,-27.558470149999998,151.79365149879573,1459,http://www.wellcamp.com.au,Australia/Queensland,TWB,AU,Westbrook,Queensland,Toowoomba,AP
-WTC,,World Trade Center,40.7,-74.01667,0,,America/New_York,NYC,US,,,,AP
 WTD,MYGW,West End,26.6883433,-78.9834305553414,32,,America/Nassau,WTD,BS,West End,West Grand Bahama,,AP
 WTE,,Wotje Island,9.4592211,170.2378303572175,49,,Pacific/Majuro,WTE,MH,Wotje,Wotje Atoll,,AP
 WTK,PAWN,Noatak,67.5662264,-162.9729713,55,,America/Anchorage,WTK,US,Kotzebue,Alaska,Northwest Arctic Borough,AP
@@ -9039,14 +8840,11 @@ WYN,YWYM,Wyndham,-15.5113853,128.15314435918117,13,,Australia/Perth,WYN,AU,Kunun
 WYS,KWYS,Yellowstone Airport,44.6889409,-111.11688394311122,6646,,America/Denver,WYS,US,West Yellowstone,Montana,Gallatin County,AP
 WZA,,Wa Airport,10.08289355,-2.5078313317209595,1003,,Africa/Accra,WZA,GH,Wa,Upper West,,AP
 WZQ,,Urad Middle Banner,41.4596,108.5345,3937,,Asia/Shanghai,WZQ,CN,Haliut,Inner Mongolia,,AP
-WZY,,Paradise Island Seaplane Base,25.0825,-77.327225,29,,America/Nassau,NAS,BS,Nassau,New Providence,,AP
-XAA,,Yerevan Stadium,40.1762089,44.5011413,3097,,Asia/Yerevan,EVN,AM,Yerevan,Yerevan,,AP
 XAI,ZHXY,Xinyang Minggang Airport,32.5401692,114.07562648032489,285,,Asia/Shanghai,XAI,CN,Minggang,Henan Sheng,,AP
 XAL,,Alamos,27.016666,-108.933334,1312,,America/Hermosillo,XAL,MX,Alamos,Sonora,,AP
 XAP,SBCH,Chapeco Airport,-27.088612,-52.629723,2146,,America/Sao_Paulo,XAP,BR,Chapeco,Santa Catarina,Chapeco,AP
 XAR,DFOY,Aribinda,14.217,-0.883,1122,,Africa/Ouagadougou,XAR,BF,Deou,Sahel,Province de l'Oudalan,AP
 XAU,SOOS,Saul,3.6151981,-53.20361524516272,656,,America/Cayenne,XAU,GF,Camopi,Guyane,Guyane,AP
-XAY,,Xayabury,18.666668,104.71667,2791,,Asia/Vientiane,XAY,LA,Con Cuong,Nghe An,,AP
 XBB,,Blubber Bay,50.0,-123.0,0,,America/Vancouver,XBB,CA,,,,AP
 XBE,CNE3,Bearskin Lake,53.96607775,-91.02530221093616,800,,America/Winnipeg,XBE,CA,,,,AP
 XBG,DFEB,Bogande,12.9810906,-0.162316,971,,Africa/Ouagadougou,XBG,BF,Bogande,Est,Gnagna Province,AP
@@ -9055,7 +8853,6 @@ XBL,,Buno Bedelle,8.45,36.333332,6335,,Africa/Addis_Ababa,XBL,ET,Bedele,Oromiya,
 XBN,AYBZ,Biniguni,-9.633333,149.3,190,,Pacific/Port_Moresby,XBN,PG,Alotau,Milne Bay,,AP
 XBO,DFEA,Boulsa,12.65,-0.566667,1013,,Africa/Ouagadougou,XBO,BF,Boulsa,Centre-Nord,Province du Namentenga,AP
 XBR,CNL3,Brockville,44.583332,-75.683334,239,,America/Toronto,XBR,CA,Brockville,Ontario,,AP
-XBW,,Killineq,42.65,-80.82,666,,America/Montreal,XBW,CA,Aylmer,Ontario,,AP
 XCH,YPXM,Christmas Island Airport,-10.5,105.666664,916,http://www.christmasislandairport.com/,Indian/Christmas,XCH,CX,Flying Fish Cove,,,AP
 XCL,CJS3,Cluff Lake,59.0,-107.0,1112,,America/Regina,XCL,CA,,,,AP
 XCM,CYCK,Chatham,42.4,-82.183334,616,,America/Toronto,XCM,CA,Walpole Island,Ontario,Lambton County,AP
@@ -9065,37 +8862,27 @@ XCR,LFOK,Chalons Vatry Airport,48.767776,4.201111,538,,Europe/Paris,PAR,FR,Maill
 XDE,DFOU,Diebougou,10.9488727,-3.2525186,961,,Africa/Ouagadougou,XDE,BF,Diebougou,Southwest,Province de la Bougouriba,AP
 XDJ,DFCJ,Djibo,14.1221595,-1.6280623,964,,Africa/Ouagadougou,XDJ,BF,Djibo,Sahel,Province du Soum,AP
 XEN,ZYXC,Xingcheng,40.733334,118.61667,30,,Asia/Shanghai,XEN,CN,Kuancheng,Hebei,,AP
-XEO,,Harbour,69.333336,-51.0,62,,America/Godthab,XEO,GL,,,,AP
-XEQ,,Harbour,60.266666,-44.63333,3,,America/Godthab,XEQ,GL,Nanortalik,Kujalleq,,AP
 XES,,Lake Geneva Aire Estates Airport,42.627777,-88.428055,1003,,America/Chicago,XES,US,Lake Geneva,Wisconsin,Walworth County,AP
-XEX,,Aerogare,48.833332,2.65,324,,Europe/Paris,PAR,FR,Torcy,Ile-de-France,Departement de Seine-et-Marne,AP
 XFN,ZHXF,Xiangyang Airport,32.151361050000006,112.2893745002323,0,,Asia/Shanghai,XFN,CN,Shuanggou,Hubei,,AP
 XFW,EDHI,Hamburg Finkenwerder Airport,52.535835,9.836945,23,,Europe/Berlin,HAM,DE,Isernhagen Farster Bauerschaft,Lower Saxony,,AP
-XFZ,,Charny,46.716667,-71.25,229,,America/Montreal,YQB,CA,Breakeyville,Quebec,Chaudiere-Appalaches,AP
 XGA,DFOG,Gaoua,10.333333,-3.183333,1026,,Africa/Ouagadougou,XGA,BF,Gaoua,Southwest,Province du Poni,AP
 XGG,DFEG,Gorom-Gorom,14.454266,-0.2182764,905,,Africa/Ouagadougou,XGG,BF,Gorom-Gorom,Sahel,Province de l'Oudalan,AP
-XGL,,Granville Lake,56.233334,-100.55,849,,America/Winnipeg,XGL,CA,,,,AP
 XGN,FNXA,Xangongo,-16.7516871,14.9660327,3635,,Africa/Luanda,XGN,AO,Outapi,Omusati,,AP
 XGR,CYLU,Kangiqsualujjuaq Airport,58.5,-65.98333,215,,America/Montreal,XGR,CA,,,,AP
-XHN,,"Guillemins, Raiway Stn",50.63333,5.56666,249,,Europe/Brussels,LGG,BE,Liege,Wallonia,Province de Liege,AP
 XIC,ZUXC,Xichang Airport,27.98876455,102.1845480169798,5112,,Asia/Shanghai,XIC,CN,Xichang,Sichuan,,AP
 XIE,VLXL,Xienglom,19.6199582,100.8121238,1830,,Asia/Vientiane,XIE,LA,Chaloem Phra Kiat,Nan,,AP
 XIG,SWSX,Xinguara,-6.966667,-48.8,810,,America/Belem,XIG,BR,Sao Geraldo do Araguaia,Para,Sao Geraldo Do Araguaia,AP
 XIJ,OKAJ,Ahmed Al Jaber,28.9347991943,47.791900634799994,409,,Asia/Kuwait,XIJ,KW,Al Ahmadi,Al Ahmadi,,AP
 XIL,ZBXH,Xilinhot Airport,43.91391455,115.95968470359296,3287,,Asia/Shanghai,XIL,CN,Xilin Hot,Inner Mongolia,,AP
 XIN,ZGXN,Xingning,24.0,116.0,0,,Asia/Shanghai,XIN,CN,Shejiang,Guangdong,,AP
-XIQ,,Harbour,69.0,-51.0,0,,America/Godthab,XIQ,GL,Ilulissat,Qaasuitsup,,AP
 XIY,ZLXY,Xianyang International Airport,34.43866385,108.7580567206632,1532,http://www.xxia.com/,Asia/Shanghai,SIA,CN,Dizhang,Shaanxi,,AP
 XJD,OTBH,Al Udeid AB,25.1173000336,51.3149986267,130,,Asia/Qatar,XJD,QA,Ar Rayyan,Baladiyat ar Rayyan,,AP
-XJH,,Hong Kong Harbour,22.2478599,114.2033843,666,,Asia/Hong_Kong,HKG,HK,Wan Chai,Wanchai,,AP
 XJM,OPMA,Mangla Airport,33.05,73.638333,826,,Asia/Karachi,XJM,PK,Jhelum,Punjab,,AP
 XKA,DFEL,Kantchari,12.4640118,1.4932335,879,,Africa/Ouagadougou,XKA,BF,Diapaga,Est,Province de la Tapoa,AP
 XKH,VLXK,Xieng Khouang Airport,19.3,103.36667,3638,,Asia/Vientiane,XKH,LA,Muang Phonsavan,Xiangkhoang,,AP
-XKO,,Kemano,53.566666,-127.933334,0,,America/Vancouver,XKO,CA,,,,AP
 XKS,CYAQ,Kasabonika,53.522354,-88.64333777775391,679,,America/Winnipeg,XKS,CA,,,,AP
 XKY,DFCA,Kaya,13.0774092,-1.1002443,984,,Africa/Ouagadougou,XKY,BF,Kaya,Centre-Nord,Province du Sanmatenga,AP
 XLB,CZWH,Lac Brochet,58.61344095,-101.46968211120176,1211,,America/Winnipeg,XLB,CA,,,,AP
-XLF,,Leaf Bay,59.0,-69.0,101,,America/Montreal,XLF,CA,,,,AP
 XLO,,Long Xuyen,10.333333,105.46667,36,,Asia/Ho_Chi_Minh,XLO,VN,Lap Vo,Dong Thap,,AP
 XLS,GOSS,St Louis,16.0532913,-16.461452955345397,36,,Africa/Dakar,XLS,SN,Saint-Louis,Saint-Louis,,AP
 XLU,DFCL,Leo,11.1,-2.1,1141,,Africa/Ouagadougou,XLU,BF,Leo,Centre-Ouest,Province de la Sissili,AP
@@ -9117,15 +8904,11 @@ XNH,ORTL,Nasiriyah Airport,30.939722,46.0925,29,,Asia/Baghdad,XNH,IQ,An Nasiriya
 XNN,ZLXN,Xining Caojiabao Airport,36.5297578,102.03821999842393,7129,,Asia/Shanghai,XNN,CN,Gaozhai,Qinghai Sheng,,AP
 XNT,ZBXT,Xingtai,37.1,114.5,280,,Asia/Shanghai,XNT,CN,Xingtai,Hebei,,AP
 XNU,DFON,Nouna,12.7433307,-3.8607879,886,,Africa/Ouagadougou,XNU,BF,Nouna,Boucle du Mouhoun,Province de la Kossi,AP
-XNY,,39th Street Ferry,40.76,-74.003,0,,America/New_York,NYC,US,Weehawken,New Jersey,Hudson County,AP
-XOF,,Stratford International Rail Station,51.51,0.06,0,,Europe/London,LON,GB,,,,AP
 XPA,DFEP,Pama,11.25,0.7,666,,Africa/Ouagadougou,XPA,BF,Pama,Est,Province de la Kompienga,AP
 XPK,CZFG,Pukatawagan,55.74924995,-101.26402499595729,928,,America/Winnipeg,XPK,CA,,,,AP
 XPL,MHSC,Coronel Enrique Soto Cano AB,14.416667,-87.61667,2024,,America/Tegucigalpa,XPL,HN,Comayagua,Comayagua,,AP
 XPP,CZNG,Poplar River,52.99613225,-97.273715983906,685,,America/Winnipeg,XPP,CA,,,,AP
 XPR,KIEN,Pine Ridge,43.016666,-102.51667,3254,,America/Denver,XPR,US,Pine Ridge,South Dakota,Shannon County,AP
-XPU,,West Kuparuk,70.333336,-149.33333,0,,America/Anchorage,XPU,US,Prudhoe Bay,Alaska,North Slope Borough,AP
-XPZ,,Harbour,43.283333,6.633333,0,,Europe/Paris,LTT,FR,Saint-Tropez,Provence-Alpes-Cote d'Azur,Departement du Var,AP
 XQP,MRQP,Quepos Airport,9.439146,-84.13335,85,,America/Costa_Rica,XQP,CR,Quepos,Puntarenas,,AP
 XQU,CAT4,Qualicum,49.337536549999996,-124.39209943796178,191,http://www.qualicumbeach.com/cms.asp?wpID=437,America/Vancouver,XQU,CA,Parksville,British Columbia,Regional District of Nanaimo,AP
 XRH,YSRI,Richmond AFB,-33.6,150.76889,67,,Australia/Sydney,XRH,AU,Richmond,New South Wales,Hawkesbury,AP
@@ -9137,22 +8920,17 @@ XSC,MBSC,International,21.515833,-71.529724,6,,America/Grand_Turk,XSC,TC,Cockbur
 XSD,KTNX,Test Range,38.033333,-117.23333,5549,,America/Los_Angeles,TPH,US,Tonopah,Nevada,Nye County,AP
 XSE,DFES,Sebba,13.4571544,0.5037673,816,,Africa/Ouagadougou,XSE,BF,Sebba,Sahel,Province du Yagha,AP
 XSI,CZSN,South Indian Lake,56.7910684,-98.90739824491808,830,,America/Winnipeg,XSI,CA,,,,AP
-XSM,,St Marys,38.283333,-76.63333,0,,America/New_York,XSM,US,Leonardtown,Maryland,Saint Mary's County,AP
 XSO,PRNO,Siocon,7.7100627,122.16196502253516,42,,Asia/Manila,XSO,PH,Siocon,Zamboanga Peninsula,Province of Zamboanga del Norte,AP
 XSP,WSSL,Seletar,1.366667,103.96667,91,,Asia/Singapore,SIN,SG,,,,AP
 XTG,YTGM,Thargomindah,-27.966667,143.76666,390,,Australia/Brisbane,XTG,AU,Bourke,New South Wales,Bourke,AP
 XTL,CYBQ,Tadoule Lake,58.706157149999996,-98.51213499738532,902,,America/Winnipeg,XTL,CA,,,,AP
 XTO,YTAM,Taroom,-25.433332,149.8,675,,Australia/Brisbane,XTO,AU,Taroom,Queensland,Banana,AP
 XTR,YTAA,Tara,-27.283333,150.46666,1000,,Australia/Brisbane,XTR,AU,Chinchilla,Queensland,Western Downs,AP
-XTT,,Etoile,48.856614,2.3522219,157,,Europe/Paris,PAR,FR,Paris,Ile-de-France,Paris,AP
 XUZ,ZSXZ,Xuzhou Guanyin Airport,34.058505499999995,117.55572772215724,0,,Asia/Shanghai,XUZ,CN,Suicheng,Jiangsu Sheng,,AP
 XVL,,Vinh Long,10.25,105.95,27,,Asia/Ho_Chi_Minh,XVL,VN,Vinh Long,Vinh Long,,AP
 XWA,KXWA,Williston Basin International Airport,48.260548400000005,-103.74677072876773,2344,https://www.flywilliston.net/,America/Toronto,XWA,US,Williston,North Dakota,Williams County,AP
-XWZ,,Nykoping,58.7531378,17.0085329,0,,Europe/Stockholm,XWZ,SE,Nykoping,Soedermanland,Nykopings Kommun,AP
-XXK,,Katrineholm,59.0167742,16.2222304,0,,Europe/Stockholm,XXK,SE,Katrineholm,Soedermanland,Katrineholms Kommun,AP
 XYA,AGGY,Yandina,-9.0932316,159.2190933,60,,Pacific/Guadalcanal,XYA,SB,Honiara,Guadalcanal,,AP
 XYE,VYYE,Ye,15.25,97.85,32,,Asia/Rangoon,XYE,MM,Sangkhla Buri,Kanchanaburi,,AP
-XYP,,Avesta Krylbo,60.1312969721,16.215858548,285,,Europe/Stockholm,XYP,SE,,,,AP
 XYR,AYED,Yellow River,-3.883333,141.78334,190,,Pacific/Port_Moresby,XYR,PG,Ubrub,Papua,,AP
 XZA,DFEZ,Zabre,11.133333,-1.0,886,,Africa/Ouagadougou,XZA,BF,Po,Centre-Sud,Nahouri Province,AP
 YAA,CAJ4,Anahim Lake,52.451219800000004,-125.30346583772354,3635,,America/Vancouver,YAA,CA,,,,AP
@@ -9160,7 +8938,6 @@ YAB,CYAB,Arctic Bay,73.03333,-85.183334,72,,America/Iqaluit,YAB,CA,,,,AP
 YAC,CYAC,Cat Lake,51.72729395,-91.82639809412494,1345,,America/Winnipeg,YAC,CA,,,,AP
 YAD,,Moose Lake,50.38333,-105.53333,1833,,America/Winnipeg,YAD,CA,,,,AP
 YAE,,Alta Lake,50.166668,-123.0,4671,,America/Vancouver,YAE,CA,,,,AP
-YAF,,Asbestos Hill,45.766666,-71.95,643,,America/Montreal,YAF,CA,Asbestos,Quebec,Estrie,AP
 YAG,CYAG,Fort Frances Municipal Airport,48.65356595,-93.44405183970974,1135,,America/Winnipeg,YAG,CA,International Falls,Minnesota,Koochiching County,AP
 YAH,CYAH,Lagrande 4,53.75,-73.65,1066,,America/Montreal,YAH,CA,,,,AP
 YAI,SCCH,Chillan,-36.6,-72.11667,367,,America/Santiago,YAI,CL,Chillan,Biobio,Provincia de Nuble,AP
@@ -9177,14 +8954,12 @@ YAS,NFSW,Yasawa Island,-16.759369999999997,177.54566412061018,26,,Pacific/Fiji,Y
 YAT,CYAT,Attawapiskat,52.9275937,-82.43111259693612,39,,America/Toronto,YAT,CA,,,,AP
 YAU,CTP9,Kattiniq/donaldson,61.66341865,-73.30730480609404,1896,,America/Montreal,YAU,CA,,,,AP
 YAV,CAW7,Miners Bay,48.86667,-123.3,150,,America/Vancouver,YAV,CA,,,,AP
-YAW,,Shearwater,44.86667,-63.61667,104,,America/Halifax,YHZ,CA,Dartmouth,Nova Scotia,,AP
 YAX,CKB6,Angling Lake Airport,53.251945,-89.565,875,,America/Winnipeg,YAX,CA,,,,AP
 YAY,CYAY,St Anthony,51.36667,-55.583332,0,,America/St_Johns,YAY,CA,Lewisporte,Newfoundland and Labrador,,AP
 YAZ,CYAZ,Tofino Airport,49.08161545,-125.77932069107595,62,http://www.acrd.bc.ca/long-beach-airport,America/Vancouver,YAZ,CA,,,,AP
 YBA,CYBA,Banff,51.166668,-115.566666,4609,,America/Edmonton,YBA,CA,Banff,Alberta,,AP
 YBB,CYBB,Kugaaruk,68.88333,-89.85,0,,America/Cambridge_Bay,YBB,CA,,,,AP
 YBC,CYBC,Baie-Comeau Airport,49.2,-68.26667,154,,America/Montreal,YBC,CA,Baie-Comeau,Quebec,Cote-Nord,AP
-YBD,,New Westminster,49.216667,-122.9,157,,America/Vancouver,YBD,CA,New Westminster,British Columbia,,AP
 YBE,CYBE,Uranium City,59.56092115,-108.48303238506128,1013,,America/Regina,YBE,CA,,,,AP
 YBF,CAE9,Bamfield,48.820617150000004,-125.11926498126282,180,,America/Vancouver,YBF,CA,,,,AP
 YBG,CYBG,Saguenay-Bagotville Airport,48.331432500000005,-70.99492946501087,501,,America/Montreal,YBG,CA,,,,AP
@@ -9193,8 +8968,6 @@ YBI,CCE4,Black Tickle,53.47021675,-55.788501079119825,19,,America/Goose_Bay,YBI,
 YBJ,,Baie Johan Beetz,50.5,-62.916668,501,,America/Montreal,YBJ,CA,,,,AP
 YBK,CYBK,Baker Lake,64.2995541,-96.07822306058817,45,,America/Rankin_Inlet,YBK,CA,,,,AP
 YBL,CYBL,Campbell River Airport,49.9540995,-125.27572028227023,291,,America/Vancouver,YBL,CA,,,,AP
-YBM,,Bronson Creek,56.7,-131.0,439,,America/Vancouver,YBM,CA,,,,AP
-YBN,,Borden,46.3,-63.783333,0,,America/Toronto,YBN,CA,Summerside,Prince Edward Island,,AP
 YBO,CBW4,Bob Quinn Lake,56.966727250000005,-130.2494541105189,1870,,America/Vancouver,YBO,CA,Ketchikan,Alaska,Ketchikan Gateway Borough,AP
 YBP,ZUYB,Yibin Caiba Airport,28.8015702,104.54960581879803,948,,Asia/Shanghai,YBP,CN,Yibin,Sichuan,,AP
 YBQ,,Telegraph Harbour,48.9820506,-123.6713198,0,,America/Vancouver,YBQ,CA,,,,AP
@@ -9213,8 +8986,6 @@ YCE,CYCE,Centralia,43.283333,-81.48333,839,,America/Toronto,YCE,CA,South Huron,O
 YCF,,Cortes Bay,50.0619618,-124.9307509,0,,America/Vancouver,YCF,CA,,,,AP
 YCG,CYCG,Castlegar Airport,49.2957603,-117.6330645059673,1617,,America/Vancouver,YCG,CA,Castlegar,British Columbia,,AP
 YCH,CYCH,Miramichi,47.0078011,-65.4492035,85,,America/Moncton,YCH,CA,Miramichi,New Brunswick,Northumberland County,AP
-YCI,,Caribou Island,61.916668,-113.25,505,,America/Toronto,YCI,CA,,,,AP
-YCJ,,Cape St James,51.933334,-131.01666,0,,America/Vancouver,YCJ,CA,,,,AP
 YCK,CYVL,Colville Lake,67.02074845,-126.12863549570841,869,,America/Yellowknife,YCK,CA,,,,AP
 YCL,CYCL,Charlo,47.990799,-66.3302994,132,,America/Moncton,YCL,CA,Carleton-sur-Mer,Quebec,Gaspesie-Iles-de-la-Madeleine,AP
 YCM,CYSN,Niagara District Airport,43.192976900000005,-79.17194175161795,321,,America/Toronto,YCM,CA,Niagara-on-the-Lake,Ontario,,AP
@@ -9225,9 +8996,7 @@ YCR,CYCR,Cross Lake,54.6089003,-97.7675598,709,,America/Winnipeg,YCR,CA,,,,AP
 YCS,CYCS,Chesterfield Inlet,63.3479211,-90.73376927744059,32,,America/Rankin_Inlet,YCS,CA,,,,AP
 YCT,CYCT,Coronation,52.0747079,-111.44789331265046,2595,,America/Edmonton,YCT,CA,Hanna,Alberta,,AP
 YCU,ZBYC,Yuncheng Airport,35.018,110.993,1242,,Asia/Shanghai,YCU,CN,Yuncheng,Shanxi Sheng,,AP
-YCV,,Cartierville,45.516666,-73.75,0,,America/Montreal,YCV,CA,,,,AP
 YCW,CYCW,Chilliwack Municipalcipal Airport,49.166668,-121.9,32,,America/Vancouver,YCW,CA,Chilliwack,British Columbia,Fraser Valley Regional District,AP
-YCX,,Gagetown,45.766666,-66.166664,0,,America/Moncton,YCX,CA,,,,AP
 YCY,CYCY,Clyde River,70.416664,-68.5,87,,America/Iqaluit,YCY,CA,,,,AP
 YCZ,CYCZ,Fairmont Hot Springs,50.3280976,-115.87288439005582,2661,,America/Edmonton,YCZ,CA,Invermere,British Columbia,,AP
 YDA,CYDA,Dawson City Airport,64.04402830000001,-139.12349875910493,1215,,America/Dawson,YDA,CA,,,,AP
@@ -9236,25 +9005,18 @@ YDC,CER3,Industrial Airport,53.2,-114.96667,2776,,America/Edmonton,YDC,CA,Drayto
 YDE,,Paradise River,53.433334,-57.233334,0,,America/Goose_Bay,YDE,CA,,,,AP
 YDF,CYDF,Deer Lake Regional Airport,49.21027,-57.399727,72,,America/St_Johns,YDF,CA,,,,AP
 YDG,CYID,Digby,44.61667,-65.76667,499,,America/Halifax,YDG,CA,Digby,Nova Scotia,,AP
-YDH,,Daniels Harbour,50.216667,-57.583332,0,,America/St_Johns,YDH,CA,,,,AP
-YDI,,Davis Inlet,55.933334,-60.95,0,,America/Goose_Bay,YDI,CA,,,,AP
 YDJ,CJL2,Hatchet Lake,58.660557,-102.539444,1362,,America/Regina,YDJ,CA,,,,AP
-YDK,,Main Duck Island,43.933334,-76.61667,0,,America/Toronto,YDK,CA,,,,AP
 YDL,CYDL,Dease Lake,58.583332,-130.03334,2600,,America/Vancouver,YDL,CA,,,,AP
 YDN,CYDN,Dauphin,51.1,-100.05,999,,America/Winnipeg,YDN,CA,Dauphin,Manitoba,,AP
 YDO,CYDO,St Methode,48.86667,-72.23333,372,,America/Montreal,YDO,CA,Dolbeau-Mistassini,Quebec,Saguenay/Lac-Saint-Jean,AP
 YDP,CYDP,Nain,56.55111965,-61.682021423249765,22,,America/Goose_Bay,YDP,CA,,,,AP
 YDQ,CYDQ,Dawson Creek,55.7414723,-120.18246225853473,2148,,America/Dawson_Creek,YDQ,CA,Dawson Creek,British Columbia,Peace River Regional District,AP
-YDR,,Broadview,50.36667,-102.583336,0,,America/Regina,YDR,CA,Esterhazy,Saskatchewan,,AP
-YDS,,Desolation Sound,49.965996,-124.72931,0,,America/Vancouver,YDS,CA,,,,AP
 YDT,CZBB,Boundary Bay Airport,49.183334,-123.183334,6,http://http://czbb.com/,America/Vancouver,YVR,CA,,,,AP
 YDU,CJL8,Kasba Lake,60.2919006,-102.501998,1131,,America/Yellowknife,YDU,CA,,,,AP
 YDV,CZTA,Bloodvein,51.7825305,-96.69189650331379,721,,America/Winnipeg,YDV,CA,,,,AP
 YDW,CKV4,Obre Lake,60.3203011,-103.126998,1195,,America/Yellowknife,YDW,CA,,,,AP
-YDX,,Doc Creek,52.05,-128.08333,0,,America/Vancouver,YDX,CA,,,,AP
 YEB,CPF2,Bar River,46.417639300000005,-84.09847131915903,591,,America/Toronto,YEB,CA,Sault Ste. Marie,Ontario,Algoma,AP
 YEC,RKTY,Yecheon,36.628844799999996,128.353105602085,354,,Asia/Seoul,YEC,KR,Mungyeong,Gyeongsangbuk-do,,AP
-YED,,Namao Field,53.5,-113.5,0,,America/Edmonton,YEA,CA,,,,AP
 YEG,CYEG,Edmonton International Airport,53.3072596,-113.5838087,2373,http://www.edmontonairports.com/,America/Edmonton,YEA,CA,Leduc,Alberta,,AP
 YEH,,Yinchuan Helanshan Airport,38.4822,106.0094,3770,,Asia/Shanghai,YEH,CN,Yinchuan,Ningxia Huizu Zizhiqu,,AP
 YEI,LTBR,Yenisehir Airport,40.25584005,29.56209181082114,764,,Europe/Istanbul,YEI,TR,Hamzabey,Bursa,,AP
@@ -9263,7 +9025,6 @@ YEL,CYEL,Elliot Lake,46.351316499999996,-82.55883994950281,1087,http://cyelont.t
 YEM,CYEM,East Manitoulin,45.842777,-81.858055,869,,America/Toronto,YEM,CA,Little Current,Ontario,,AP
 YEN,CYEN,Estevan,49.166668,-102.98333,1905,,America/Regina,YEN,CA,Estevan,Saskatchewan,,AP
 YEO,EGDY,Yeovilton,51.016666,-2.55,75,,Europe/London,YEO,GB,Sherborne,England,Dorset,AP
-YEP,,Estevan Point,49.38333,-126.53333,0,,America/Vancouver,YEP,CA,,,,AP
 YEQ,AYYK,Yenkis,-5.10940055,143.9173608942616,3692,,Pacific/Port_Moresby,YEQ,PG,Wabag,Enga,,AP
 YER,CYER,Fort Severn,56.033333,-87.833336,48,,America/Toronto,YER,CA,,,,AP
 YES,OISY,Yasouj,30.699774,51.55276,5939,,Asia/Tehran,YES,IR,Yasuj,Kohgiluyeh va Buyer Ahmad,,AP
@@ -9299,12 +9060,10 @@ YGO,CYGO,Gods Lake Narrows Airport,54.5588933,-94.4913969,617,,America/Winnipeg,
 YGP,CYGP,Michel-Pouliot Gaspe Airport,48.766666,-64.48333,112,,America/Montreal,YGP,CA,Gaspe,Quebec,Gaspesie-Iles-de-la-Madeleine,AP
 YGQ,CYGQ,Geraldton,49.733334,-86.95,1144,,America/Toronto,YGQ,CA,,,,AP
 YGR,CYGR,Iles De La Madeleine,47.36667,-61.9,35,,America/Halifax,YGR,CA,Souris,Prince Edward Island,,AP
-YGS,,Germansen,55.767659,-124.6928225,0,,America/Vancouver,YGS,CA,,,,AP
 YGT,CYGT,Igloolik Airport,69.36376179999999,-81.81482446871043,174,,America/Iqaluit,YGT,CA,,,,AP
 YGV,CYGV,Havre St Pierre,50.283493899999996,-63.603875594040474,124,,America/Montreal,YGV,CA,,,,AP
 YGW,CYGW,Kuujjuarapik Airport,55.2824753,-77.75632598579428,34,,America/Montreal,YGW,CA,,,,AP
 YGX,CYGX,Gillam,56.356811949999994,-94.7121796275236,476,,America/Winnipeg,YGX,CA,,,,AP
-YGY,,Deception,62.1139505,-74.56168740274171,0,,America/Montreal,YGY,CA,,,,AP
 YGZ,CYGZ,Grise Fiord,76.42610205,-82.90958377076656,146,,America/Iqaluit,YGZ,CA,,,,AP
 YHA,CCP4,Port Hope Simpson,52.52758035,-56.280771003168525,347,,America/St_Johns,YHA,CA,,,,AP
 YHB,CYHB,Hudson Bay,52.86667,-102.416664,1175,,America/Regina,YHB,CA,Hudson Bay,Saskatchewan,,AP
@@ -9343,7 +9102,6 @@ YIW,ZSYW,Yiwu Airport,29.342204799999998,120.02868898781665,262,,Asia/Shanghai,Y
 YJA,CYJA,Jasper Airport,52.9972169,-118.0612726,3350,,America/Edmonton,YJA,CA,Jasper Park Lodge,Alberta,,AP
 YJF,CYJF,Fort Liard,60.23598605,-123.47007861169465,708,,America/Yellowknife,YJF,CA,,,,AP
 YJN,CYJN,St Jean,45.333332,-73.333336,136,,America/Montreal,YJN,CA,Saint-Jean-sur-Richelieu,Quebec,Monteregie,AP
-YJO,,Johnny Mountain,56.666668,-131.11667,0,,America/Vancouver,YJO,CA,,,,AP
 YJP,CEC4,Jasper-hinton,53.319168,-117.75306,4006,,America/Edmonton,YJP,CA,Hinton,Alberta,,AP
 YJS,ZKSE,Samjiyon,41.90659475,128.4101275564893,4547,,Asia/Pyongyang,YJS,KP,Changbai,Jilin Sheng,,AP
 YJT,CYJT,Stephenville,48.543099299999994,-58.559355183351315,84,,America/St_Johns,YJT,CA,Stephenville,Newfoundland and Labrador,,AP
@@ -9354,7 +9112,6 @@ YKE,CJT3,Knee Lake,53.05,-94.666664,625,,America/Winnipeg,YKE,CA,,,,AP
 YKF,CYKF,Region of Waterloo International Airport,43.455854849999994,-80.38573581162505,1055,http://www.waterlooairport.ca/,America/Toronto,YKF,CA,Cambridge,Ontario,,AP
 YKG,CYAS,Kangirsuk Airport,60.0292262,-69.99784334087558,403,,America/Montreal,YKG,CA,,,,AP
 YKH,ZYYK,Yingkou Lanqi Airport,40.54587515,122.36111194233801,0,,Asia/Shanghai,YKH,CN,Qingshiling,Liaoning,,AP
-YKI,,Kennosao Lake,58.98,23.86,0,,America/Winnipeg,YKI,CA,Uuemoisa,Laeaene,Ridala Parish,AP
 YKJ,CYKJ,Key Lake,57.2560997,-105.617996,1679,,America/Regina,YKJ,CA,,,,AP
 YKK,CAP7,Kitkatla,53.0,-130.0,0,,America/Vancouver,YKK,CA,,,,AP
 YKL,CYKL,Schefferville Airport,54.783333,-64.816666,1709,,America/Montreal,YKL,CA,,,,AP
@@ -9368,12 +9125,10 @@ YKU,CSU2,Chisasibi,53.805560400000005,-78.9175650509388,43,,America/Montreal,YKU
 YKX,CYKX,Kirkland Lake,48.15,-80.03333,1157,,America/Toronto,YKX,CA,Kirkland Lake,Ontario,,AP
 YKY,CYKY,Kindersley,51.45,-109.166664,2277,,America/Regina,YKY,CA,Kindersley,Saskatchewan,,AP
 YKZ,CYKZ,Buttonville Municipalcipal,43.86667,-79.36667,650,http://www.torontoairways.com/,America/Toronto,YTO,CA,Richmond Hill,Ontario,York,AP
-YLA,,Langara,54.233334,-133.01666,0,,America/Vancouver,YLA,CA,Craig,Alaska,Annette Island Reserve,AP
 YLB,CYLB,Lac Biche,54.766666,-112.01667,1884,,America/Edmonton,YLB,CA,Lac La Biche,Alberta,,AP
 YLC,CYLC,Kimmirut,62.84737215,-69.87541408078025,175,,America/Iqaluit,YLC,CA,,,,AP
 YLD,CYLD,Chapleau,47.8209323,-83.3549858,1470,,America/Toronto,YLD,CA,Thessalon,Ontario,,AP
 YLE,CEM3,Wha Ti,63.15,-117.26667,882,,America/Yellowknife,YLE,CA,,,,AP
-YLF,,LaForges,54.183334,-72.48333,0,,America/Montreal,YLF,CA,,,,AP
 YLG,YYAL,Yalgoo,-28.354116949999998,116.68231759482914,0,,Australia/Perth,YLG,AU,Melville,Western Australia,Yalgoo,AP
 YLH,CYLH,Lansdowne House,52.1955986,-87.9341965,834,,America/Toronto,YLH,CA,,,,AP
 YLI,EFYL,Ylivieska,64.054201,24.7213378,252,"http://www.ylivieska.fi/alltypes.asp?d_type=5&menu_id=17643&menupath=16922,17643",Europe/Helsinki,YLI,FI,Ylivieska,Northern Ostrobothnia,Ylivieska,AP
@@ -9382,7 +9137,6 @@ YLK,CYLS,Lake Simcoe Regional,44.4841513,-79.5460696,972,http://www.lakesimcoeai
 YLL,CYLL,Lloydminster,53.31182105,-110.0726685775977,2193,,America/Edmonton,YLL,CA,Lloydminster,Saskatchewan,,AP
 YLM,,Clinton Creek,64.4,-140.55,2040,,America/Whitehorse,YLM,CA,,,,AP
 YLN,,Yilan,46.38333,129.5,0,,Asia/Shanghai,YLN,CN,Yinglan,Heilongjiang Sheng,,AP
-YLO,,Shilo,49.781666,-99.638336,0,,America/Winnipeg,YLO,CA,Carberry,Manitoba,,AP
 YLP,,Mingan,50.283333,-64.15,70,,America/Montreal,YLP,CA,,,,AP
 YLQ,CYLQ,La Tuque,47.5,-72.833336,548,,America/Montreal,YLQ,CA,La Tuque,Quebec,Mauricie,AP
 YLR,CYLR,Leaf Rapids,56.5133018,-99.9852982,959,,America/Winnipeg,YLR,CA,,,,AP
@@ -9394,13 +9148,11 @@ YLX,,Long Point,59.35,-94.68,0,,America/Toronto,YLX,CA,,,,AP
 YLY,CYNJ,Langley Regional,49.100854049999995,-122.62808976800964,34,,America/Vancouver,YLY,CA,Langley,British Columbia,,AP
 YMA,CYMA,Mayo,63.6166166,-135.8690225156807,1653,,America/Whitehorse,YMA,CA,,,,AP
 YMB,CAD5,Merritt,50.11667,-120.75,2080,,America/Vancouver,YMB,CA,Merritt,British Columbia,,AP
-YMC,,Maricourt Airstrip,56.566666,-70.816666,0,,America/Montreal,YMC,CA,,,,AP
 YMD,,Mould Bay,76.25,-119.5,30,,America/Rankin_Inlet,YMD,CA,,,,AP
 YME,CYME,Matane,48.833332,-67.51667,102,,America/Montreal,YME,CA,Matane,Quebec,Bas-Saint-Laurent,AP
 YMF,,Montagne Harbor,48.816666,-123.2,0,,America/Vancouver,YMF,CA,Point Roberts,Washington,Whatcom County,AP
 YMG,CYMG,Manitouwadge,49.0828647,-85.86072073634787,1198,,America/Toronto,YMG,CA,,,,AP
 YMH,CYMH,Mary's Harbour,52.3027992,-55.8471985,38,,America/St_Johns,YMH,CA,,,,AP
-YMI,,Minaki,49.97063745,-94.70090530242254,0,,America/Winnipeg,YMI,CA,Warroad,Minnesota,Roseau County,AP
 YMJ,CYMJ,Moose Jaw / Air Vice Marshal C. M. Mcewen Airport,50.38333,-105.53333,1892,,America/Regina,YMJ,CA,Moose Jaw,Saskatchewan,,AP
 YMK,USDK,Mys-Kamenny,68.46217225000001,73.59914344849958,98,,Asia/Yekaterinburg,YMK,RU,Mys-Kamennyy,Yamalo-Nenetskiy Avtonomnyy Okrug,,AP
 YML,CYML,Charlevoix,47.65,-70.166664,977,,America/Montreal,YML,CA,La Malbaie,Quebec,Capitale-Nationale,AP
@@ -9408,7 +9160,6 @@ YMM,CYMM,Fort McMurray International Airport,56.65179285,-111.22838956157571,121
 YMN,CYFT,Makkovik Airport,55.166668,-59.166668,234,,America/Goose_Bay,YMN,CA,,,,AP
 YMO,CYMO,Moosonee,51.29122475,-80.6106136870039,30,,America/Toronto,YMO,CA,Iroquois Falls,Ontario,,AP
 YMP,CAT5,Port McNeil,50.61111,-127.09722,225,,America/Vancouver,YMP,CA,,,,AP
-YMR,,Merry Island,55.483334,-77.51667,0,,America/Vancouver,YMR,CA,,,,AP
 YMS,SPMS,Yurimaguas,-5.89407265,-76.11400054301723,587,,America/Lima,YMS,PE,Yurimaguas,Loreto,Provincia de Alto Amazonas,AP
 YMT,CYMT,Chibougamau Airport,49.916668,-74.36667,1270,,America/Montreal,YMT,CA,Chibougamau,Quebec,Nord-du-Quebec,AP
 YMU,CAV7,Mansons Landing SPB,50.07145,-124.98369,0,,America/Vancouver,YMU,CA,,,,AP
@@ -9420,18 +9171,14 @@ YNB,OEYN,Yanbu Airport,24.148030149999997,38.0626738365901,26,https://gaca.gov.s
 YNC,CYNC,Wemindji,53.010420749999994,-78.83166404601303,66,,America/Montreal,YNC,CA,,,,AP
 YND,CYND,Gatineau Airport,45.483334,-75.63333,211,http://www.ego-airport.ca/english/propos_ego/,America/Toronto,YOW,CA,,,,AP
 YNE,CYNE,Norway House Airport,53.95694255,-97.84823872487667,734,,America/Winnipeg,YNE,CA,,,,AP
-YNF,,Deer Lake/Stephenville,48.946945,-57.94389,0,,America/St_Johns,YNF,CA,,,,AP
 YNG,KYNG,Youngstown,41.26073745,-80.67497084511017,1192,,America/New_York,YNG,US,Howland Center,Ohio,Trumbull County,AP
 YNH,CYNH,Hudson Hope,56.0,-121.9,2220,,America/Edmonton,YNH,CA,Chetwynd,British Columbia,,AP
-YNI,,Nitchequon,53.166668,-70.96667,0,,America/Montreal,YNI,CA,Fermont,Quebec,Cote-Nord,AP
 YNJ,ZYYJ,Yanji Chaoyangchuan Airport,42.8787858,129.4487048951637,624,,Asia/Shanghai,YNJ,CN,,,,AP
-YNK,,Nootka Sound,50.083332,-125.916664,0,,America/Vancouver,YNK,CA,,,,AP
 YNL,CYNL,Points North Landing,58.2688607,-104.079962,1605,,America/Regina,YNL,CA,,,,AP
 YNM,CYNM,Matagami,49.76001035,-77.7987925166334,918,,America/Montreal,YNM,CA,,,,AP
 YNN,,Yandi,-22.766666,119.23333,0,,Australia/Perth,YNN,AU,,,,AP
 YNO,CKQ3,North Spirit Lake,52.5,-92.416664,1082,,America/Winnipeg,YNO,CA,,,,AP
 YNP,CNH2,Natuashish Airport,55.91337420000001,-61.18168410059596,30,,America/Goose_Bay,YNP,CA,,,,AP
-YNR,,Arnes,50.833332,-97.0,0,,America/Winnipeg,YNR,CA,,,,AP
 YNS,CYHH,Nemiscau Airport,49.74167,-76.74167,802,,America/Montreal,YNS,CA,Lebel-sur-Quevillon,Quebec,Nord-du-Quebec,AP
 YNT,ZSYT,Yantai Laishan International Airport,37.407326,121.3711,154,http://www.ytairport.com.cn/,Asia/Shanghai,YNT,CN,Laishan,Shandong Sheng,,AP
 YNX,CSK6,Snap Lake,63.593511500000005,-110.90408549820063,1557,,America/Yellowknife,YNX,CA,,,,AP
@@ -9445,7 +9192,6 @@ YOG,CYKP,Ogoki,51.6588906,-85.90071375324194,594,,America/Toronto,YOG,CA,,,,AP
 YOH,CYOH,Oxford House,54.9344837,-95.27646737422647,663,,America/Winnipeg,YOH,CA,,,,AP
 YOI,,Opinaca,52.2211,-76.60716027805023,692,,America/Montreal,YOI,CA,,,,AP
 YOJ,CYOJ,Footner Lake Airport,58.618332,-117.168335,1110,,America/Edmonton,YOJ,CA,,,,AP
-YOK,,Yokohama,35.466667,139.46666,0,,Asia/Tokyo,YOK,JP,Minami-rinkan,Kanagawa,,AP
 YOL,DNYO,Yola Airport,9.25639295,12.431171311028873,599,http://www.faannigeria.org/nigeria-airport.php?airport=16,Africa/Lagos,YOL,NG,Jimeta,Adamawa,,AP
 YON,VQTY,Yongphulla Airport,27.2559902,91.51530783849674,9000,,Asia/Thimphu,YON,BT,Trashigang,Tashigang,,AP
 YOO,CYOO,Oshawa,43.9227762,-78.8950068,460,http://www.oshawa-airport.com/,America/Toronto,QWA,CA,Oshawa,Ontario,,AP
@@ -9453,7 +9199,6 @@ YOP,CYOP,Rainbow Lake,58.490890300000004,-119.40651632509058,1759,,America/Edmon
 YOS,CYOS,Billy Bishop Regional,44.59028,-80.8375,1007,,America/Toronto,YOS,CA,,,,AP
 YOT,LLYT,Yotvata,29.8987599,35.0669918,249,,Asia/Jerusalem,YOT,IL,Al Quwayrah,Ma'an,,AP
 YOW,CYOW,Ottawa/Macdonald-Cartier International Airport,45.32203645,-75.66726438915012,374,http://www.ottawa-airport.ca/,America/Toronto,YOW,CA,,,,AP
-YOY,,Valcartier,45.0,-72.0,0,,America/Montreal,YOY,CA,Newport,Vermont,Orleans County,AP
 YPA,CYPA,Glass Field,53.2166982,-105.675088,1405,,America/Regina,YPA,CA,Prince Albert,Saskatchewan,,AP
 YPB,CBS8,Port Alberni,49.2318993,-124.8150024,250,http://www.acrd.bc.ca/avra,America/Vancouver,YPB,CA,,,,AP
 YPC,CYPC,Paulatuk,69.36133480000001,-124.0745327827381,15,,America/Yellowknife,YPC,CA,,,,AP
@@ -9467,7 +9212,6 @@ YPL,CYPL,Pickle Lake,51.208332,-90.208336,1267,,America/Atikokan,YPL,CA,,,,AP
 YPM,CYPM,Pikangikum,51.8196983,-93.9732971,1114,,America/Winnipeg,YPM,CA,,,,AP
 YPN,CYPN,Port Menier,49.83726715,-64.28671832305594,167,,America/Montreal,YPN,CA,,,,AP
 YPO,CYPO,Peawanuck,54.9892371,-85.44585341456714,173,,America/Toronto,YPO,CA,,,,AP
-YPP,,Pine Point,60.85,-114.85,0,,America/Yellowknife,YPP,CA,Hay River,Northwest Territories,,AP
 YPQ,CYPQ,Peterborough,44.3,-78.316666,628,,America/Toronto,YPQ,CA,Peterborough,Ontario,,AP
 YPR,CYPR,Digby Island Airport,54.3167,-130.3999939,116,http://www.ypr.ca/,America/Vancouver,YPR,CA,,,,AP
 YPS,CYPD,Port Hawkesbury,45.656802049999996,-61.367937113526764,377,http://www.porthawkesburyairport.com/,America/Halifax,YPS,CA,,,,AP
@@ -9480,7 +9224,6 @@ YQA,CYQA,Muskoka,44.9754065,-79.30674035378686,925,,America/Toronto,YQA,CA,Brace
 YQB,CYQB,Quebec City Jean Lesage International Airport,46.792174849999995,-71.38577821056776,244,http://www.aeroportdequebec.com/,America/Montreal,YQB,CA,L'Ancienne-Lorette,Quebec,,AP
 YQC,CYHA,Quaqtaq,61.333332,-69.63333,103,,America/Montreal,YQC,CA,,,,AP
 YQD,CYQD,Clearwater,53.966667,-101.1,887,,America/Winnipeg,YQD,CA,The Pas,Manitoba,,AP
-YQE,,Kimberley,49.666668,-115.98333,0,,America/Vancouver,YQE,CA,Kimberley,British Columbia,Regional District of East Kootenay,AP
 YQF,CYQF,Red Deer Regional Airport,52.18576525,-113.88599970807856,2968,,America/Edmonton,YQF,CA,Penhold,Alberta,,AP
 YQG,CYQG,Windsor International Airport,42.274166,-82.96389,622,,America/Toronto,YQG,CA,Windsor,Ontario,,AP
 YQH,CYQH,Watson Lake,60.11951655,-128.81643855172976,2255,,America/Whitehorse,YQH,CA,Watson Lake,Yukon,,AP
@@ -9504,7 +9247,6 @@ YRA,CYRA,Rae Lakes,64.1162588,-117.31158204272573,723,,America/Yellowknife,YRA,C
 YRB,CYRB,Resolute Bay Airport,74.7166791,-94.96858868629138,215,,America/Resolute,YRB,CA,,,,AP
 YRC,,Refuge Cove SPB,48.526764,-71.05734,0,,America/Vancouver,YRC,CA,Saguenay,Quebec,Saguenay/Lac-Saint-Jean,AP
 YRD,,Dean River,52.82399555,-126.96497259176871,62,,America/Vancouver,YRD,CA,Houston,British Columbia,,AP
-YRE,,Resolution Island,61.5,-65.0,0,,America/Pangnirtung,YRE,CA,,,,AP
 YRF,CYCA,Cartwright,53.6826849,-57.04176422196099,40,,America/Goose_Bay,YRF,CA,,,,AP
 YRG,CCZ2,Rigolet,54.333332,-58.416668,180,,America/Goose_Bay,YRG,CA,,,,AP
 YRI,CYRI,Riviere Du Loup,47.833332,-69.53333,427,http://www.ville.riviere-du-loup.qc.ca/anglais/aeroport.php,America/Montreal,YRI,CA,Riviere-du-Loup,Quebec,Bas-Saint-Laurent,AP
@@ -9521,7 +9263,6 @@ YRV,CYRV,Revelstoke,50.9621846,-118.18376908076137,1459,,America/Vancouver,YRV,C
 YSA,CSB2,Sable Island,44.0,-60.0,4,http://www.sableislandairport.com/Photo-Gallery-1.html,America/Halifax,YSA,CA,Port Hawkesbury,Nova Scotia,,AP
 YSB,CYSB,Sudbury Airport,46.62296,-80.79592,1141,,America/Toronto,YSB,CA,Greater Sudbury,Ontario,,AP
 YSC,CYSC,Sherbrooke,45.416668,-71.9,792,,America/Montreal,YSC,CA,Sherbrooke,Quebec,Estrie,AP
-YSD,,Suffield,50.2,-111.166664,0,,America/Edmonton,YSD,CA,Bow Island,Alberta,,AP
 YSE,CYSE,Squamish,49.781667,-123.161944,171,,America/Vancouver,YSE,CA,,,,AP
 YSF,CYSF,Stony Rapids,59.250382200000004,-105.84143669997378,805,,America/Regina,YSF,CA,,,,AP
 YSG,CYLK,Lutselke,62.41861,-110.075554,596,,America/Yellowknife,YSG,CA,,,,AP
@@ -9535,28 +9276,19 @@ YSN,CZAM,Salmon Arm,50.6828003,-119.228996,1751,http://www.salmonarm.ca/index.as
 YSO,CCD4,Postville Airport,54.916668,-59.966667,193,,America/Goose_Bay,YSO,CA,,,,AP
 YSP,CYSP,Marathon,48.75,-86.35,1035,,America/Toronto,YSP,CA,,,,AP
 YSQ,ZYSQ,Spring Island,59.45,-1.78,459,,America/Vancouver,YSQ,CA,Sandwick,Scotland,Shetland Islands,AP
-YSR,,Nanisivik,73.75,-84.5,0,,America/Iqaluit,YSR,CA,,,,AP
-YSS,,Slate Island,-33.932922,151.1799,0,,America/Toronto,YSS,CA,Mascot,New South Wales,Botany Bay,AP
 YST,CYST,Ste Therese Point,53.85,-94.65,773,,America/Winnipeg,YST,CA,,,,AP
 YSU,CYSU,Summerside,49.0,-57.983334,56,,America/Halifax,YSU,CA,Corner Brook,Newfoundland and Labrador,,AP
-YSV,,Saglek,58.583332,-62.5,0,,America/Goose_Bay,YSV,CA,,,,AP
 YSX,CAW8,Shearwater,52.13333,-128.06667,0,,America/Vancouver,YSX,CA,,,,AP
 YSY,CYSY,Sachs Harbour,71.99336145000001,-125.2487637741074,282,,America/Yellowknife,YSY,CA,,,,AP
-YSZ,,Squirrel Cove,50.05,-124.916664,0,,America/Vancouver,YSZ,CA,,,,AP
 YTA,CYTA,Pembroke And Area Airport,45.861668,-77.24944,529,http://www.flycyta.ca/,America/Toronto,YTA,CA,,,,AP
 YTB,CAY4,Hartley Bay,53.4229782,-129.2509186,0,,America/Vancouver,YTB,CA,,,,AP
-YTC,,Sturdee Valley Airport,57.2,-127.15,0,,America/Vancouver,YTC,CA,Sturdee,British Columbia,,AP
 YTD,CZLQ,Thicket Portage,55.3179916,-97.7019681,678,,America/Winnipeg,YTD,CA,,,,AP
 YTE,CYTE,Cape Dorset,64.2301779,-76.52438761760335,164,,America/Iqaluit,YTE,CA,,,,AP
 YTF,CYTF,Alma,48.5098133,-71.6502761,445,,America/Montreal,YTF,CA,Alma,Quebec,Saguenay/Lac-Saint-Jean,AP
 YTG,CAV5,Sullivan Bay,50.8851419,-126.826895,0,,America/Vancouver,YTG,CA,Campbell River,British Columbia,,AP
 YTH,CYTH,Thompson,55.79753,-97.8605,729,,America/Winnipeg,YTH,CA,,,,AP
-YTI,,Triple Island,-29.456944,142.06223,0,,America/Vancouver,YTI,CA,,,,AP
-YTJ,,Terrace Bay,48.75,-87.166664,0,,America/Toronto,YTJ,CA,Marathon,Ontario,,AP
-YTK,,Tulugak,59.5,-77.75,0,,America/Montreal,YTK,CA,,,,AP
 YTL,CYTL,Big Trout,53.81987275,-89.90035954975068,729,,America/Winnipeg,YTL,CA,,,,AP
 YTM,CYFJ,La Macaza,46.515556,-74.75528,827,http://www.mtia.ca/,America/Montreal,YTM,CA,Riviere-Rouge,Quebec,Laurentides,AP
-YTN,,Riviere Au Tonnerre,50.283333,-64.75,0,,America/Montreal,YTN,CA,,,,AP
 YTP,CAB4,Seaplane Base,49.154446,-125.40806,0,,America/Vancouver,YAZ,CA,Ucluelet,British Columbia,Regional District of Alberni-Clayoquot,AP
 YTQ,CYTQ,Tasiujuaq Airport,58.6678,-69.95633,122,,America/Montreal,YTQ,CA,,,,AP
 YTR,CYTR,Trenton,44.1,-77.583336,283,,America/Toronto,YTR,CA,Quinte West,Ontario,,AP
@@ -9595,15 +9327,12 @@ YVV,CYVV,Wiarton/Keppel Airport,44.666668,-81.166664,729,http://wiartonairport.c
 YVZ,CYVZ,Deer Lake,52.666668,-94.5,1092,,America/Winnipeg,YVZ,CA,,,,AP
 YWA,CYWA,Petawawa,45.9,-77.28333,427,,America/Toronto,YWA,CA,,,,AP
 YWB,CYKG,Kangiqsujuaq Airport,61.5877768,-71.92727553346413,501,,America/Montreal,YWB,CA,,,,AP
-YWF,,Downtown Waterfront Heliport,44.63333,-63.583332,0,,America/Halifax,YHZ,CA,Halifax,Nova Scotia,,AP
 YWG,CYWG,Winnipeg James Armstrong Richardson International Airport,49.91046085,-97.2379281374448,783,http://www.waa.ca/,America/Winnipeg,YWG,CA,Winnipeg,Manitoba,,AP
 YWH,CYWH,Victoria Inner Harbour Airport,48.4253301,-123.3904221,0,,America/Vancouver,YYJ,CA,Victoria,British Columbia,,AP
 YWJ,CYWJ,Deline,65.166664,-123.5,703,,America/Yellowknife,YWJ,CA,,,,AP
 YWK,CYWK,Wabush Airport,52.92290375,-66.86590757996974,1808,,America/Goose_Bay,YWK,CA,,,,AP
 YWL,CYWL,Williams Lake Airport,52.1831017,-122.054,3085,,America/Vancouver,YWL,CA,,,,AP
 YWM,CCA6,Williams Harbour,52.335438,-56.01282,70,,America/St_Johns,YWM,CA,,,,AP
-YWN,,Winisk,55.25,-85.11667,0,,America/Toronto,YWN,CA,Hearst,Ontario,,AP
-YWO,,Lupin,65.75816295,-111.24983314553009,0,,America/Yellowknife,YWO,CA,Kugluktuk,Nunavut,,AP
 YWP,CYWP,Webequie,52.95896385,-87.37462162415397,685,,America/Toronto,YWP,CA,Greenstone,Ontario,,AP
 YWQ,CTM3,Chute-Des-Passes,49.887222,-71.25389,1310,,America/Montreal,YWQ,CA,Pont Rouge,Quebec,,AP
 YWR,CNJ8,White River,48.583332,-85.333336,1380,,America/Toronto,YWR,CA,,,,AP
@@ -9612,9 +9341,7 @@ YWY,CYWY,Wrigley,63.2099933,-123.434656,489,,America/Yellowknife,YWY,CA,,,,AP
 YXC,CYXC,Canadian Rockies International Airport,49.612860850000004,-115.78391098859873,3082,,America/Edmonton,YXC,CA,Cranbrook,British Columbia,,AP
 YXD,CYXD,Edmonton City Centre (Blatchford Field) Airport,53.566666,-113.51667,2202,http://corporate.flyeia.com/general_aviation/edmonton_city_centre,America/Edmonton,YEA,CA,Edmonton,Alberta,,AP
 YXE,CYXE,Saskatoon International Airport,52.172371999999996,-106.69161089220799,1653,,America/Regina,YXE,CA,Saskatoon,Saskatchewan,,AP
-YXF,,Snake River,59.033333,-122.433334,0,,America/Whitehorse,YXF,CA,,,,AP
 YXH,CYXH,Medicine Hat Regional Airport,50.0185704,-110.72105082680821,2352,,America/Edmonton,YXH,CA,Medicine Hat,Alberta,,AP
-YXI,,Killaloe,45.55,-77.416664,0,,America/Toronto,YXI,CA,Petawawa,Ontario,,AP
 YXJ,CYXJ,North Peace Regional Airport,56.2404316,-120.73587153404387,2280,,America/Dawson_Creek,YXJ,CA,,,,AP
 YXK,CYXK,Rimouski,48.433334,-68.55,82,,America/Montreal,YXK,CA,Rimouski,Quebec,Bas-Saint-Laurent,AP
 YXL,CYXL,Sioux Lookout Airport,50.1138992,-91.9052963,1258,,America/Winnipeg,YXL,CA,Dryden,Ontario,,AP
@@ -9649,12 +9376,10 @@ YYW,CYYW,Armstrong,50.283333,-89.03333,1058,,America/Toronto,YYW,CA,Thunder Bay,
 YYY,CYYY,Mont Joli Airport,48.6086006,-68.2080994,172,,America/Montreal,YYY,CA,Mont-Joli,Quebec,Bas-Saint-Laurent,AP
 YYZ,CYYZ,Pearson International Airport,43.681583,-79.61146,569,http://www.gtaa.com/,America/Toronto,YTO,CA,Etobicoke,Ontario,,AP
 YZA,CAZ5,Ashcroft,50.666668,-121.333336,2034,,America/Vancouver,YZA,CA,Ashcroft,British Columbia,Thompson-Nicola Regional District,AP
-YZC,,Beatton River,57.433334,-121.333336,0,,America/Vancouver,YZC,CA,Fort St. John,British Columbia,,AP
 YZE,CYZE,Gore Bay,45.885277,-82.56778,635,,America/Toronto,YZE,CA,Elliot Lake,Ontario,,AP
 YZF,CYZF,Yellowknife Airport,62.457386650000004,-114.44111467626608,675,,America/Yellowknife,YZF,CA,Yellowknife,Northwest Territories,,AP
 YZG,CYZG,Salluit,62.1792874,-75.66740714445996,743,,America/Montreal,YSW,CA,Iqaluit,Nunavut,,AP
 YZH,CYZH,Slave Lake,55.2930984,-114.7770004,1912,http://slavelakeairport.com,America/Edmonton,YZH,CA,Slave Lake,Alberta,,AP
-YZM,,Buchans,48.833332,-56.86667,0,,America/St_Johns,YZM,CA,Deer Lake,Newfoundland and Labrador,,AP
 YZP,CYZP,Sandspit Airport,53.2532095,-131.8126998451329,21,,America/Vancouver,YZP,CA,,,,AP
 YZR,CYZR,Sarnia Airport,42.998174399999996,-82.30882048716478,594,,America/Toronto,YZR,CA,Sarnia,Ontario,Lambton County,AP
 YZS,CYZS,Coral Harbour Airport,64.197343,-83.35760462035266,210,,America/Coral_Harbour,YZS,CA,Rankin Inlet,Nunavut,,AP
@@ -9684,7 +9409,6 @@ ZBL,,Biloela,-24.4,150.51666,0,,Australia/Brisbane,ZBL,AU,Biloela,Queensland,Ban
 ZBM,CZBM,Bromont,45.316666,-72.833336,375,,America/Montreal,ZBM,CA,Granby,Quebec,Monteregie,AP
 ZBO,YBWN,Bowen,-20.016666,148.21666,8,,Australia/Brisbane,ZBO,AU,Bowen,Queensland,Whitsunday,AP
 ZBR,OIZC,Chah-Bahar Airport,25.436478,60.379562,43,,Asia/Tehran,ZBR,IR,Konarak,Sistan and Baluchestan,,AP
-ZBU,,Aarhus Limo,56.162939,10.203921,0,,Europe/Copenhagen,AAR,DK,,,,AP
 ZBY,VLSB,Sayaboury,19.242310850000003,101.70990990145297,962,,Asia/Vientiane,ZBY,LA,Sainyabuli,Xiagnabouli,,AP
 ZCL,MMZC,La Calera Airport,22.8,-102.55,7141,http://www.oma.aero/es/aeropuertos/zacatecas/,America/Mexico_City,ZCL,MX,Zacatecas,Zacatecas,,AP
 ZCO,SCQP,La Araucanía International Airport,-38.925,-72.651389,333,,America/Santiago,ZCO,CL,Temuco,Araucania,Provincia de Cautin,AP
@@ -9696,14 +9420,11 @@ ZEM,CZEM,East Main,52.25,-78.51667,24,,America/Montreal,ZEM,CA,Matagami,Quebec,N
 ZEN,AYZA,Zenag,-6.95,146.61667,3200,,Pacific/Port_Moresby,ZEN,PG,Bulolo,Morobe,Bulolo,AP
 ZER,VEZO,Zero,27.633333,93.833336,5403,,Asia/Kolkata,ZER,IN,Ziro,Arunachal Pradesh,Lower Subansiri,AP
 ZFA,CZFA,Faro,63.216667,-133.36667,2351,,America/Whitehorse,ZFA,CA,Whitehorse,Yukon,,AP
-ZFB,,Old Fort Bay,51.583332,-57.916668,0,,America/Blanc-Sablon,ZFB,CA,,,,AP
 ZFD,CZFD,Fond-du-Lac Airport,59.3344002,-107.1819992,814,,America/Regina,ZFD,CA,Fond du Lac,Saskatchewan,,AP
 ZFL,,South Trout Lake,50.833332,-93.65,0,,America/Winnipeg,ZFL,CA,,,,AP
 ZFM,CZFM,Fort Mcpherson,67.477776,-134.95277,116,,America/Yellowknife,ZFM,CA,Fort McPherson,Northwest Territories,,AP
 ZFN,CZFN,Tulita,64.90878649999999,-125.56970777368883,332,,America/Yellowknife,ZFN,CA,Norman Wells,Northwest Territories,,AP
-ZFU,,Aruja,-23.3964516,-46.3214444,0,,America/Sao_Paulo,ZFU,BR,Aruja,Sao Paulo,Aruja,AP
 ZFW,CEB5,Fairview,56.066666,-118.38333,2166,,America/Edmonton,ZFW,CA,Fairview,Alberta,,AP
-ZFZ,,Buffalo Depew Rr,42.8864468,-78.8783689,0,,America/New_York,BUF,US,,,,AP
 ZGF,CZGF,Grand Forks,49.0155983,-118.430999,1720,,America/Vancouver,ZGF,CA,Grand Forks,British Columbia,,AP
 ZGI,CZGI,Gods River Airport,54.683334,-94.166664,627,,America/Winnipeg,ZGI,CA,,,,AP
 ZGL,YSGW,South Galway,-25.6770073,142.0951185,116,,Australia/Brisbane,ZGL,AU,Innamincka,South Australia,,AP
@@ -9711,41 +9432,31 @@ ZGM,FLNA,Ngoma,-15.958333,25.934444,3400,,Africa/Lusaka,ZGM,ZM,Namwala,Southern,
 ZGR,CZGR,Little Grand Rapids,52.04476915,-95.46527983522518,1005,,America/Winnipeg,ZGR,CA,Lac du Bonnet,Manitoba,,AP
 ZGS,CTT5,Gethsemani,50.333332,-60.666668,90,,America/Blanc-Sablon,ZGS,CA,,,,AP
 ZGU,NVSQ,Gaua,-14.2208883,167.5897821,100,,Pacific/Efate,ZGU,VU,Sola,Torba,,AP
-ZGY,,Kuching Port,5.96667003632,100.550003052,0,,Asia/Kuching,ZGY,MY,Gurun,Kedah,,AP
 ZHA,ZGZJ,Zhanjiang Airport,21.21472515,110.35930740779222,125,,Asia/Shanghai,ZHA,CN,Haitou,Guangdong,,AP
-ZHI,,Grenchen,47.1810051,7.415404983009971,0,,Europe/Zurich,ZHI,CH,Grenchen,Solothurn,Bezirk Lebern,AP
 ZHM,VGSH,Shamshernagar,24.396824,91.9128379,56,,Asia/Dhaka,ZHM,BD,Kailashahar,Tripura,North Tripura,AP
 ZHP,CZHP,High Prairie,55.394484649999995,-116.48689885394634,1974,,America/Edmonton,ZHP,CA,High Prairie,Alberta,,AP
 ZHY,ZLZW,Zhongwei Airport,37.5710553,105.15233253938072,8202,,Asia/Shanghai,ZHY,CN,,,,AP
 ZIA,UUBW,Zhukovsky International Airport,55.5527354,38.14866077990443,377,http://zia.aero/,Europe/Moscow,MOW,RU,Zhukovskiy,Moskovskaya,,AP
 ZIC,SCTO,Victoria,-38.2441698,-72.34748426534875,1148,,America/Santiago,ZIC,CL,Victoria,Araucania,Provincia de Malleco,AP
-ZIE,,Harbour (Eolie Island),38.533333,14.9,0,,Europe/Rome,ZIE,IT,Santa Marina Salina,Sicily,Messina,AP
 ZIG,GOGG,Ziguinchor,12.5565053,-16.27910290979382,75,,Africa/Dakar,ZIG,SN,Ziguinchor,Ziguinchor,,AP
 ZIH,MMZH,Ixtapa/Zihuatanejo Internacional Airport,17.606783,-101.464066,26,,America/Mexico_City,ZIH,MX,Colonia Aeropuerto,Guerrero,Zihuatanejo de Azueta,AP
-ZIP,,Harbour (Eolie Island),49.871666,11.646667,0,,Europe/Rome,ZIP,IT,Emtmannsberg,Bavaria,Upper Franconia,AP
 ZIS,HLZN,Alzintan Airport,31.76947005,12.247363631615961,2080,,Africa/Tripoli,ZIS,LY,Az Zintan,Sha`biyat al Jabal al Gharbi,,AP
 ZIX,UEVV,Zhigansk Airport,66.796667,123.361389,292,,Asia/Yakutsk,ZIX,RU,Zhigansk,Sakha,,AP
 ZIZ,,Zamzama,26.733334,67.666664,128,,Asia/Karachi,ZIZ,PK,Johi,Sindh,,AP
 ZJG,CZJG,Jenpeg,54.51907755,-98.04607141974127,729,,America/Winnipeg,ZJG,CA,Thompson,Manitoba,,AP
 ZJN,CZJN,Swan River,52.1162532,-101.2352046,1100,,America/Winnipeg,ZJN,CA,Swan River,Manitoba,,AP
-ZJT,,Tanjung Pelepas Port,1.362896654,103.5554116,0,,Asia/Kuala_Lumpur,ZJT,MY,Pekan Nenas,Johor,,AP
 ZKB,FLKY,Kasaba Bay,-8.5249996,30.6630001,2780,,Africa/Lusaka,ZKB,ZM,Mpulungu,Northern,,AP
 ZKE,CZKE,Kaschechewan,52.333332,-81.333336,35,,America/Toronto,ZKE,CA,Kapuskasing,Ontario,,AP
 ZKG,CTK6,Kegaska,50.19551115,-61.2672140605186,32,,America/Blanc-Sablon,ZKG,CA,Havre-Saint-Pierre,Quebec,Cote-Nord,AP
 ZKL,,Steenkool,-2.102778,133.51666,1133,,Asia/Jayapura,ZKL,ID,Bintuni,West Papua,,AP
-ZKM,,Sette Cama,-2.533,9.7670002,0,,Africa/Libreville,ZKM,GA,Gamba,Ogooue-Maritime,,AP
 ZKP,UESU,Zyryanka Airport,65.738333,150.707778,140,,Asia/Srednekolymsk,ZKP,RU,Zyryanka,Sakha,Verkhnekolymsky District,AP
-ZLG,,El Gouera,20.842222,-17.078333,0,,Europe/Budapest,ZLG,HU,Nouadhibou,Dakhlet Nouadhibou,,AP
 ZLO,MMZO,Manzanillo Airport,19.113333,-104.350555,30,http://manzanillo.aeropuertosgap.com.mx/index.php?lang=eng,America/Mexico_City,ZLO,MX,Manzanillo,Colima,Manzanillo,AP
 ZLT,CTU5,La Tabatiere,50.83005065,-58.97623897020986,102,,America/Blanc-Sablon,ZLT,CA,,,,AP
-ZLW,,Pasir Gudang Port,1.44492244,103.9066392,0,,Asia/Kuala_Lumpur,ZLW,MY,Kampung Pasir Gudang Baru,Johor,,AP
 ZLX,HSZA,Zalingei Airport,12.9447732,23.5644544,2953,,Africa/Khartoum,ZLX,SD,Zalingei,Central Darfur,,AP
 ZMD,,Sena Madureira,-9.083333,-68.75,540,,America/Rio_Branco,ZMD,BR,Sena Madureira,Acre,Sena Madureira,AP
 ZMH,CZML,South Cariboo Regional Airport,51.735007249999995,-121.33244427979807,3129,,America/Vancouver,ZMH,CA,Williams Lake,British Columbia,,AP
-ZML,,Milwaukee General Mitchell,43.0387949,-87.9065334,0,,America/Chicago,MKE,US,Milwaukee,Wisconsin,Milwaukee County,AP
 ZMM,MMZM,Zamora,19.983334,-102.26667,5141,,America/Mexico_City,ZMM,MX,Fraccionamiento Monte Olivo,Michoacan,Zamora,AP
 ZMT,CZMT,Masset Airport,54.0258747,-132.1238959748132,25,,America/Vancouver,ZMT,CA,Metlakatla,Alaska,Annette Island Reserve,AP
-ZMY,,Harbour,30.55,116.43333,0,,Asia/Shanghai,ZMY,CN,Meicheng,Anhui Sheng,,AP
 ZNA,CAC8,Nanaimo Harbour,49.05293,-123.87485,0,,America/Vancouver,YCD,CA,Ladysmith,British Columbia,Cowichan Valley Regional District,AP
 ZNC,ZNC,Nyac,60.9782629,-160.0029934,460,,America/Anchorage,ZNC,US,Bethel,Alaska,Bethel Census Area,AP
 ZND,DRZR,Zinder,13.7779059,8.98236761070802,1516,,Africa/Niamey,ZND,NE,Zinder,Zinder,,AP
@@ -9758,7 +9469,6 @@ ZPB,CZPB,Sachigo Lake Airport,53.88868915,-92.18777514350165,876,,America/Winnip
 ZPC,SCPC,Pucon,-39.76389,-71.63333,853,,America/Santiago,ZPC,CL,San Martin de los Andes,Neuquen,Departamento de Lacar,AP
 ZPH,KZPH,Zephyrhills,28.2265942,-82.15837574200106,90,,America/New_York,ZPH,US,Zephyrhills,Florida,Pasco County,AP
 ZPO,CZPO,Pine House,55.516666,-106.583336,1278,,America/Regina,ZPO,CA,La Ronge,Saskatchewan,,AP
-ZQF,,Fohren,49.8647566,6.7866615,0,,Europe/Berlin,ZQF,DE,Bekond,Rheinland-Pfalz,,AP
 ZQN,NZQN,Queenstown Airport,-45.019299950000004,168.74343994415125,1171,,Pacific/Auckland,ZQN,NZ,Queenstown,Otago,Queenstown-Lakes District,AP
 ZQS,,Queen Charlotte Island,53.0,-132.0,0,,America/Vancouver,ZQS,CA,,,,AP
 ZQW,EDRZ,Zweibruecken Airport,49.209210999999996,7.39756145986936,1132,http://www.edrz-airport.de,Europe/Berlin,SCN,DE,,,,AP
@@ -9770,7 +9480,6 @@ ZRM,WAJI,Sarmi,-1.87386245,138.7539608322614,10,,Asia/Jayapura,ZRM,ID,Sarmi,Papu
 ZSA,MYSM,San Salvador Airport,24.06595985,-74.53177411551994,24,,America/Nassau,ZSA,BS,Cockburn Town,San Salvador,,AP
 ZSE,FMEP,St Pierre dela Reunion,-21.333332,55.483334,59,http://www.grandsudreunion.org/FR2004/aeroport.php,Indian/Reunion,ZSE,RE,Saint-Pierre,Reunion,Reunion,AP
 ZSJ,CZSJ,Sandy Lake,53.033333,-93.23333,951,,America/Winnipeg,ZSJ,CA,,,,AP
-ZSP,,St Paul,47.916668,-69.25,0,,America/Montreal,ZSP,CA,Saint-Antonin,Quebec,Bas-Saint-Laurent,AP
 ZSS,DISS,Sassandra,4.9303139,-6.1304294,203,,Africa/Abidjan,ZSS,CI,Sassandra,Bas-Sassandra,,AP
 ZST,CZST,Stewart,55.9356393,-129.98266963141435,24,,America/Vancouver,ZST,CA,,,,AP
 ZSW,CZSW,Seal Cove,54.333332,-130.28334,0,,America/Vancouver,YPR,CA,Prince Rupert,British Columbia,Skeena-Queen Charlotte Regional District,AP
@@ -9791,14 +9500,10 @@ ZVG,,Springvale,-17.866667,127.583336,0,,Australia/Perth,ZVG,AU,Halls Creek,West
 ZVK,VLSK,Savannakhet,16.556469,104.76031944401174,509,,Asia/Vientiane,ZVK,LA,Savannakhet,Savannahkhet,,AP
 ZWA,FMND,Andapa,-14.6517,49.6206017,1552,,Indian/Antananarivo,ZWA,MG,Andapa,Sava,Andapa District,AP
 ZWL,CZWL,Wollaston Lake,58.10592265,-103.17224020533234,1360,,America/Regina,ZWL,CA,Flin Flon,Manitoba,,AP
-ZWR,,Kota Kinabalu Port,5.976474,116.115777,0,,Asia/Kuching,ZWR,MY,Kota Kinabalu,Sabah,,AP
 ZXT,UBTT,Heydar Aliyev,40.485,49.983612,36,,Asia/Baku,BAK,AZ,Zabrat,Baki,,AP
-ZYD,,Lisbon TP,40.032368,124.28081,0,,Europe/Lisbon,LIS,PT,Langtou,Liaoning,,AP
-ZYF,,Faro TP,37.0153597,-7.935113,0,,Europe/Lisbon,FAO,PT,Faro,Faro,Faro,AP
 ZYI,ZUZY,Zunyi Xinzhou Airport,27.666668,106.833336,2920,,Asia/Shanghai,ZYI,CN,Zunyi,Guizhou Sheng,,AP
 ZYL,VGSY,Civil Airport,24.957598,91.870476,50,,Asia/Dhaka,ZYL,BD,Sylhet,Sylhet,,AP
 ZZE,UBBZ,Zangilan International Airport,39.09512199158182,46.7336184452897,1604,,Asia/Baku,ZZE,AZ,Karabakh,,,AP
-ZZN,,Nationaltheatret RailS,59.9138688,10.7522454,0,,Europe/Oslo,OSL,NO,Oslo,Oslo,Oslo,AP
 ZZO,UHSO,Zonalnoye,50.660627399999996,142.77230001516781,479,,Asia/Sakhalin,ZZO,RU,Tymovskoye,Sakhalin,,AP
 ZZU,FWUU,Mzuzu,-11.443044350000001,34.01193333198202,4115,,Africa/Blantyre,ZZU,MW,Mzuzu,Northern Region,Mzimba District,AP
 ZZV,KZZV,Zanesville,39.933334,-82.01667,900,,America/New_York,ZZV,US,Zanesville,Ohio,Muskingum County,AP

--- a/airports.csv
+++ b/airports.csv
@@ -6725,7 +6725,7 @@ RSB,YRSB,Roseberth,-25.8215655,139.623569,147,,Australia/Brisbane,RSB,AU,,,,AP
 RSD,MYER,South Eleuthera Airport,24.8910397,-76.18381779273884,29,,America/Nassau,RSD,BS,Governor's Harbour,Central Eleuthera,,AP
 RSE,,Rose Bay,-33.8,151.21666,216,,Australia/Sydney,SYD,AU,Castlecrag,New South Wales,Willoughby,AP
 RSH,PARS,Russian SPB,61.783054,-161.31917,49,,America/Anchorage,RSH,US,,,,AP
-RSI,,Rio Sidra,8.966667,-80.333336,475,,America/Panama,RSI,PA,Puerto Escondido,Colon,,AP
+RSI,OERS,Red Sea International Airport,25.630278,37.078333,128,,Asia/Riyadh,RSI,SA,Hanak,Tabuk Province,,AP
 RSJ,W49,Rosario SPB,48.63333,-122.85,715,,America/Los_Angeles,RSJ,US,,,,AP
 RSK,WASC,Ransiki,-1.4952691,134.1726687,114,,Asia/Jayapura,RSK,ID,Ransiki,West Papua,,AP
 RSL,KRSL,Russell,38.88333,-98.85,1814,http://www.russellcity.org/airport.php,America/Chicago,RSL,US,Russell,Kansas,Russell County,AP

--- a/airports.csv
+++ b/airports.csv
@@ -1610,18 +1610,15 @@ CSH,ULAS,Solovky,65.02944,35.733334,32,,Europe/Moscow,CSH,RU,Rabocheostrovsk,Rep
 CSI,YCAS,Casino,-28.880727450000002,153.05894080670998,68,,Australia/Sydney,CSI,AU,Casino,New South Wales,Richmond Valley,AP
 CSJ,,Cape St Jacques,10.033333,111.0,0,,Asia/Ho_Chi_Minh,CSJ,VN,Phu Quy,Binh Thuan,,AP
 CSK,GOGS,Cap Skirring,12.39821835,-16.750892885762433,49,,Africa/Dakar,CSK,SN,Oussouye,Ziguinchor,,AP
-CSL,,O Sullivan Army Air Field,35.236668,-120.63917,167,,America/Los_Angeles,CSL,US,,,,AP
 CSM,KCSM,Sherman,35.539165,-96.933334,892,,America/Chicago,CSM,US,Meeker,Oklahoma,Lincoln County,AP
 CSN,KCXP,Carson City,39.194508049999996,-119.74021540263364,4698,http://flycarsoncity.com/,America/Los_Angeles,CSN,US,Carson City,Nevada,Carson City,AP
 CSO,EDBC,Cochstedt,51.8559128,11.415935734337616,580,,Europe/Berlin,CSO,DE,Cochstedt,Saxony-Anhalt,,AP
-CSP,,Cape Spencer C G Heliport,58.1991004944,-136.639007568,0,,America/Juneau,CSP,US,,,,AP
 CSQ,KCSQ,Municipal,41.066666,-94.36667,1289,http://www.crestoniowa.gov/crestonmunicipalairport.htm,America/Chicago,CSQ,US,Creston,Iowa,Union County,AP
 CSR,,Casuarito,5.833333,-68.133333,242,,America/Bogota,CSR,CO,,,,AP
 CSS,SSCL,Cassilandia,-18.983334,-51.983334,1669,,America/Campo_Grande,CSS,BR,Cassilandia,Mato Grosso do Sul,Cassilandia,AP
 CST,NFCS,Castaway,-17.5,177.5,0,,Pacific/Fiji,CST,FJ,Lautoka,Western,,AP
 CSU,SSSC,Santa Cruz Do Sul,-29.68380235,-52.41103406734325,626,,America/Sao_Paulo,CSU,BR,Santa Cruz do Sul,Rio Grande do Sul,Santa Cruz Do Sul,AP
 CSV,KCSV,Memorial,35.95111,-85.084724,1873,http://www.crossvilletn.gov/index.php/departments/airport,America/Chicago,CSV,US,Crossville,Tennessee,Cumberland County,AP
-CSW,MMSL,Cabo San Lucas International Airport,22.9475,-109.936944,666,,America/Mazatlan,CSW,MX,Los Cabos,Baja California Sur,,AP
 CSX,ZGHA,Changsha Huanghua Airport,28.190666049999997,113.21991433924589,45,,Asia/Shanghai,CSX,CN,,,,AP
 CSY,UWKS,Cheboksary Airport,56.13333,47.266666,416,,Europe/Moscow,CSY,RU,Cheboksary,Chuvashia,Cheboksarskiy Rayon,AP
 CSZ,SAZC,Brigadier Hector Ruiz,-37.433334,-61.88333,754,,America/Argentina/Buenos_Aires,CSZ,AR,Coronel Suarez,Buenos Aires,Partido de Coronel Suarez,AP
@@ -1672,11 +1669,9 @@ CUS,,Municipal,31.833332,-107.63333,4022,,America/Denver,CUS,US,Columbus,New Mex
 CUT,SAZW,Cutral,-38.9,-69.0,1870,,America/Argentina/Salta,CUT,AR,Plaza Huincul,Neuquen,,AP
 CUU,MMCU,Gen Fierro Villalobos Airport,28.704048,-105.96952,4422,,America/Chihuahua,CUU,MX,Ninguno [CERESO],Chihuahua,Aquiles Serdan,AP
 CUV,SVCG,Casigua,11.066667,-70.95,55,,America/Caracas,CUV,VE,Dabajuro,Falcon,Municipio Dabajuro,AP
-CUW,,Cube Cove,57.941666,-134.75,0,,America/Juneau,CUW,US,,,,AP
 CUX,,Cuddihy Field,27.75,-97.33611,0,,America/Chicago,CRP,US,,,,AP
 CUY,YCUE,Cue,-27.4469307,117.9177756,1430,,Australia/Perth,CUY,AU,,,,AP
 CUZ,SPZO,Alejandro Velasco Astete International Airport,-13.5362553,-71.93777215348605,10774,http://www.corpac.gob.pe/,America/Lima,CUZ,PE,Cusco,Cusco,Provincia de Cusco,AP
-CVA,,Civic Ar Heli,40.496666,-80.23583,1122,,America/New_York,PIT,US,,,,AP
 CVB,AYCB,Chungribu,-4.8066201,144.7149963,101,,Pacific/Port_Moresby,CVB,PG,,,,AP
 CVC,YCEE,Cleve,-33.709539050000004,136.50503364234316,583,,Australia/Adelaide,CVC,AU,Cleve,South Australia,Cleve,AP
 CVE,SKCV,Covenas,9.40092,-75.6913,78,,America/Bogota,CVE,CO,San Antero,Cordoba,,AP
@@ -1690,7 +1685,6 @@ CVM,MMCV,Ciudad Victoria Airport,23.713888,-98.96528,757,,America/Monterrey,CVM,
 CVN,KCVN,Clovis Municipal Airport,34.42584135,-103.07970767542656,4179,,America/Denver,CVN,US,Texico,New Mexico,Curry County,AP
 CVO,KCVO,Corvallis Municipal Airport,44.497222,-123.289444,250,http://www.ci.corvallis.or.us/,America/Los_Angeles,CVO,US,Corvallis,Oregon,Corvallis,AP
 CVQ,YCAR,Carnarvon Airport,-24.883429,113.66358,32,,Australia/Perth,CVQ,AU,,,,AP
-CVR,,Hughes,33.975,-118.417,26,,America/Los_Angeles,CVR,US,Marina del Rey,California,Los Angeles County,AP
 CVS,KCVS,Cannon AFB,34.382445,-103.320967,4251,http://www.cannon.af.mil/,America/Denver,CVN,US,Cannon Air Force Base,New Mexico,Curry County,AP
 CVT,EGBE,Coventry Airport,52.3699147,-1.481289537442902,203,http://www.coventryairport.co.uk/,Europe/London,CVT,GB,Ryton on Dunsmore,England,Warwickshire,AP
 CVU,LPCR,Corvo Island (Azores) Airport,39.7,-31.1,1778,,Atlantic/Azores,CVU,PT,,,,AP
@@ -1698,13 +1692,10 @@ CWA,KCWA,Central Wisconsin Airport,44.7727172,-89.66716494412262,1236,,America/C
 CWB,SBCT,Afonso Pena International Airport,-25.5322,-49.176544,2956,,America/Sao_Paulo,CWB,BR,Sao Jose dos Pinhais,Parana,Sao Jose Dos Pinhais,AP
 CWC,UKLN,Chernivtsi International Airport,48.26047165,25.9785329173081,728,,Europe/Kiev,CWC,UA,Chernivtsi,Chernivtsi,,AP
 CWF,KCWF,Chennault International.,30.305918,-93.23189,29,http://www.chennault.org/,America/Chicago,LCH,US,Moss Bluff,Louisiana,Calcasieu Parish,AP
-CWG,,Callaway Gardens,32.8418797,-84.8784817,892,,America/New_York,CWG,US,,,,AP
 CWI,KCWI,Clinton,41.829445,-90.33195,698,,America/Chicago,CWI,US,Camanche,Iowa,Clinton County,AP
 CWJ,ZPCW,Cangyuan Washan Airport,23.2772471,99.37478144463962,5744,,Asia/Chongqing,CWJ,CN,Mengdong,Yunnan,,AP
 CWK,VECT,Chitrakoot Airport,25.167694,80.9358,1050,,Asia/Kolkata,CWK,IN,,,,AP
 CWL,EGFF,Cardiff Airport,51.39850525,-3.339210332510528,252,http://www.cwlfly.com/,Europe/London,CWL,GB,Rhoose,Wales,Vale of Glamorgan,AP
-CWO,,Ft Wolter AAF,32.8,-98.11667,872,,America/Chicago,MWL,US,,,,AP
-CWP,,Campbellpore,33.766666,72.433334,1141,,Asia/Karachi,CWP,PK,Sanjwal,Punjab,,AP
 CWR,YCWI,Cowarie,-27.7125889,138.32563455173027,49,,Australia/Adelaide,CWR,AU,,,,AP
 CWS,78WA,Center Island,47.485,-122.83139,311,,America/Los_Angeles,CWS,US,,,,AP
 CWT,YCWR,Cowra,-33.844791900000004,148.6487317274209,944,,Australia/Sydney,CWT,AU,Cowra,New South Wales,Cowra,AP
@@ -1729,7 +1720,6 @@ CYA,MTCA,Les Cayes,18.2700495,-73.7919727086445,196,,America/Port-au-Prince,CYA,
 CYB,MWCB,Charles Kirkconnel International Airport,19.690191,-79.87941,55,,America/Cayman,CYB,KY,,,,AP
 CYC,,Caye Chapel,17.666668,-88.833336,104,,America/Belize,CYC,BZ,Shipyard,Orange Walk,,AP
 CYD,MZMF,San Ignacio Town Airstrip,17.104722,-89.101389,351,,America/Belize,CYD,BZ,Benque Viejo del Carmen,Cayo,,AP
-CYE,,Crystal Lake,41.210278,-75.83222,1843,,America/New_York,CYE,US,Georgetown,Pennsylvania,Luzerne County,AP
 CYF,PACK,Chefornak Sea Plane Base,60.216667,-164.2,49,,America/Nome,CYF,US,,,,AP
 CYG,YCRG,Corryong,-36.25,147.9,1551,,Australia/Melbourne,CYG,AU,,,,AP
 CYI,RCKU,Chiayi Airport,23.459325550000003,120.39371622493724,82,http://www.cya.gov.tw/web/english/index.asp,Asia/Taipei,CYI,TW,Taibao,Taiwan,Chiayi,AP
@@ -1764,7 +1754,6 @@ CZU,SKCZ,Corozal Airport,9.3375,-75.282776,544,,America/Bogota,CZU,CO,Morroa,Suc
 CZW,EPRU,Czestochowa,50.816666,19.1,859,,Europe/Warsaw,CZW,PL,Czestochowa,Silesian Voivodeship,Czestochowa,AP
 CZX,ZSCG,Changzhou Airport,31.9184829,119.77841391568919,39,,Asia/Shanghai,CZX,CN,Luoxi,Jiangsu Sheng,,AP
 CZY,YUNY,Cluny,-24.516666,139.53334,275,,Australia/Brisbane,CZY,AU,,,,AP
-CZZ,,Campo,37.1,-102.583336,4314,,America/Los_Angeles,CZZ,US,Springfield,Colorado,Baca County,AP
 DAA,KDAA,Davison AAF,37.5,-78.75,669,,America/New_York,DAA,US,Appomattox,Virginia,Appomattox County,AP
 DAB,KDAB,Daytona Beach International Airport,29.181643899999997,-81.05426943447691,29,,America/New_York,DAB,US,Daytona Beach,Florida,Volusia County,AP
 DAC,VGHS,Hazrat Shahjalal International Airport,23.84229135,90.40375285964708,32,,Asia/Dhaka,DAC,BD,Tungi,Dhaka,,AP
@@ -1772,7 +1761,6 @@ DAD,VVDN,Da Nang International Airport,16.0425792,108.19716127833769,26,,Asia/Ho
 DAF,,Daup,-4.733333,144.95,311,,Pacific/Port_Moresby,DAF,PG,,,,AP
 DAG,KDAG,Barstow-Daggett,34.25,-117.333336,4632,,America/Los_Angeles,DAG,US,Crestline,California,San Bernardino County,AP
 DAH,,Dathina,13.866667,46.13333,2483,,Asia/Aden,DAH,YE,Mudiyah,Abyan,Mudiyah,AP
-DAJ,,Dauan Island,-9.433333,142.53334,187,,Australia/Brisbane,DAJ,AU,,,,AP
 DAK,HEDK,Dakhla,25.414722,28.999166,495,,Africa/Cairo,DAK,EG,,,,AP
 DAL,KDAL,Dallas Love Field,32.8450229,-96.8498413,495,http://www.dallas-lovefield.com/,America/Chicago,DFW,US,University Park,Texas,Dallas County,AP
 DAM,OSDI,Damascus International Airport,33.4108334,36.51391166837934,1991,,Asia/Damascus,DAM,SY,Harran al `Awamid,Rif-dimashq,,AP
@@ -1810,18 +1798,14 @@ DCI,LIED,Rafsu Decimomannu,39.35,8.966667,49,,Europe/Rome,DCI,IT,Villasor,Sardin
 DCK,DCK,Dahl Creek Airport,66.9441134,-156.9057329,219,,America/Anchorage,DCK,US,,,,AP
 DCM,LFCK,Mazamet Airport,43.5563998,2.289003274410029,741,,Europe/Paris,DCM,FR,Lagarrigue,Midi-Pyrenees,Departement du Tarn,AP
 DCN,YCIN,RAAF Curtin,-17.580804,123.82154363476033,236,,Australia/Perth,DRB,AU,,,,AP
-DCP,,Cabin Plant Heliport,59.23361111,-121.691388,2112,,America/Vancouver,DCP,CA,Fort Nelson,British Columbia,Fort Nelson,AP
-DCR,,Decatur Hi-Way,40.833332,-84.933334,790,,America/Indiana/Indianapolis,DCR,US,Decatur,Indiana,Adams County,AP
 DCT,MYRD,Duncan Town,22.25,-75.75,0,,America/Nassau,DCT,BS,Duncan Town,Ragged Island,,AP
 DCU,KDCU,Pyor,34.6,-86.98333,610,,America/Chicago,DCU,US,Decatur,Alabama,Morgan County,AP
 DCY,ZUDC,Daocheng Yading Airport,29.31628015,100.06055347834386,14455,,Asia/Shanghai,DCY,CN,Sangpi,Sichuan,,AP
 DDC,KDDC,Dodge City Municipal Airport,37.7611827,-99.9657378,2582,,America/Chicago,DDC,US,Dodge City,Kansas,Ford County,AP
 DDD,VRMU,Dhaalu Airport,2.66648215,72.88611679765515,0,,Indian/Maldives,DDD,MV,Kudahuvadhoo,Dhaalu Atholhu,,AP
 DDG,ZYDD,Langtou Airport,40.02644170000001,124.2815411011791,29,http://www.ddcei.gov.cn/english/index.html,Asia/Shanghai,DDG,CN,,,,AP
-DDI,,Daydream Island,-20.266666,148.81667,0,,Australia/Brisbane,DDI,AU,,,,AP
 DDM,,Dodoima,-8.483333,145.16667,0,,Pacific/Port_Moresby,DDM,PG,,,,AP
 DDN,YDLT,Delta Downs,-16.916668,141.3,45,,Australia/Brisbane,DDN,AU,,,,AP
-DDP,,Dorado Beach,18.483334,-66.15,0,,America/Puerto_Rico,DDP,PR,Levittown,Toa Baja,,AP
 DDR,,Shigatse Tingri Airport,28.604567,86.798,14108,,Asia/Shanghai,DDR,CN,Xigaze,,,AP
 DDU,OPDD,Dadu,26.75,67.75,101,,Asia/Karachi,DDU,PK,Dadu,Sindh,,AP
 DEA,OPDG,Dera Ghazi Khan Airport,29.9462594,70.5222664,383,,Asia/Karachi,DEA,PK,,,,AP
@@ -1835,7 +1819,6 @@ DEI,FSSD,Denis Island,-3.80192305,55.667200670657294,49,,Indian/Mahe,DEI,SC,,,,A
 DEL,VIDP,Indira Gandhi International Airport,28.5551678,77.08473847979485,757,http://www.newdelhiairport.in/,Asia/Kolkata,DEL,IN,Gurgaon,Haryana,Gurgaon,AP
 DEM,HADD,Dembidollo,8.5508879,34.85988637487796,5055,,Africa/Addis_Ababa,DEM,ET,Dembi Dolo,Oromiya,,AP
 DEN,KDEN,Denver International Airport,39.8606676,-104.68536732610298,5347,http://www.flydenver.com/,America/Denver,DEN,US,Lochbuie,Colorado,Weld County,AP
-DEO,,Hyatt Regency Heliport,42.3,-83.166664,587,,America/Detroit,DEO,US,Melvindale,Michigan,Wayne County,AP
 DEP,VEDZ,Deparizo,27.35,94.0,1115,,Asia/Kolkata,DEP,IN,,,,AP
 DEQ,,Deqing Moganshan Airport,30.504167,120.107222,29,,Asia/Shanghai,DEQ,CN,Leidian,Zhejiang Sheng,,AP
 DER,AYDE,Derim,-6.1,147.08333,5269,,Pacific/Port_Moresby,DER,PG,,,,AP
@@ -1848,12 +1831,10 @@ DFI,KDFI,Memorial,41.283333,-84.36667,685,http://www.defiance-county.com/airport
 DFP,YDDF,Drumduff,-16.0,143.33333,416,,Australia/Brisbane,DFP,AU,,,,AP
 DFW,KDFW,Dallas/Fort Worth International Airport,32.89651945,-97.0465220537124,574,https://www.dfwairport.com/,America/Chicago,DFW,US,Grapevine,Texas,Tarrant County,AP
 DGA,,Dangriga,17.183332,-88.566666,337,,America/Belize,DGA,BZ,,,,AP
-DGB,,Danger Bay,58.083332,-152.75,374,,America/Anchorage,DGB,US,,,,AP
 DGC,HADB,Degahbur,8.233333,43.583332,3553,,Africa/Addis_Ababa,DGC,ET,Baligubadle,Woqooyi Galbeed,,AP
 DGD,YDGA,Dalgaranga,-27.818056,117.30139,1371,,Australia/Perth,DGD,AU,,,,AP
 DGE,YMDG,Mudgee,-32.56243675,149.61393426355673,1515,,Australia/Sydney,DGE,AU,Mudgee,New South Wales,Mid-Western Regional,AP
 DGF,CAL3,Douglas Lake,50.1645563,-120.1702593,2703,,America/Vancouver,DGF,CA,,,,AP
-DGG,,Daugo,68.03,-162.9,898,,Pacific/Port_Moresby,DGG,PG,,,,AP
 DGH,VEDO,Deoghar International Airport,24.444722,86.7025,833,https://www.aai.aero/en/airports/deoghar,Asia/Kolkata,DGH,IN,Deoghar,Jharkhand,,AP
 DGK,,Dugong,-22.134167,35.443611,0,,Africa/Maputo,DGK,MZ,,,,AP
 DGL,KDGL,Douglas Municipal,31.35,-109.566666,3959,,America/Phoenix,DUG,US,,,,AP
@@ -1875,7 +1856,6 @@ DHI,VNDH,Dhangarhi,28.683332,80.63333,554,,Asia/Kathmandu,DHI,NP,Dhangarhi,Far W
 DHL,,Dhala,13.7375,44.729168,4763,,Asia/Aden,DHL,YE,Dhalie,Ad Dali',Ad Dhale'e,AP
 DHM,VIGG,Gaggal Airport,32.3,76.26667,7900,,Asia/Kolkata,DHM,IN,Dharmsala,Himachal Pradesh,Kangra,AP
 DHN,KDHN,Dothan Regional Airport,31.32003875,-85.44995912385775,324,,America/Chicago,DHN,US,Midland City,Alabama,Dale County,AP
-DHO,,Horn River,59.4593,-122.2553,2299,,America/Vancouver,DHO,CA,,,,AP
 DHR,EHKD,De Kooy/Den Helder Airport,52.95,4.75,32,,Europe/Amsterdam,DHR,NL,Den Helder,North Holland,Gemeente Den Helder,AP
 DHT,KDHT,Dalhart,36.066666,-102.51667,3959,,America/Chicago,DHT,US,Dalhart,Texas,Dallam County,AP
 DHX,WARD,Dhoho International Airport,-7.761672,111.951521,371,,Asia/Jakarta,DHX,ID,,,,AP
@@ -1888,7 +1868,6 @@ DIK,KDIK,Dickinson Regional Airport,46.833332,-102.9,2506,http://dickinsonairpor
 DIL,WPDL,Comoro Airport,-8.549616,125.525,68,,Asia/Dili,DIL,TL,Dili,Dili,,AP
 DIM,DIDK,Dimbokro,6.75,-4.766667,282,,Africa/Abidjan,DIM,CI,Dimbokro,Lacs,,AP
 DIN,VVDB,Dien Bien Airport,21.3949323,103.00703615040092,1519,,Asia/Ho_Chi_Minh,DIN,VN,Dien Bien Phu,Huyen Dien Bien,,AP
-DIO,,Diomede Island,65.75,-168.95,141,,America/Nome,DIO,US,,,,AP
 DIP,DFED,Diapaga,12.033333,2.033333,892,,Africa/Ouagadougou,DIP,BF,,,,AP
 DIQ,SNDV,Divinopolis,-20.18147045,-44.870044517354316,2562,,America/Sao_Paulo,DIQ,BR,Divinopolis,Minas Gerais,Divinopolis,AP
 DIR,HADR,Aba Tenna D Yilma Airport,9.61338,41.857994,3802,,Africa/Addis_Ababa,DIR,ET,Dire Dawa,Dire Dawa,,AP
@@ -1910,7 +1889,6 @@ DJU,BIDV,Djupivogur,64.6430303,-14.2775558,16,,Atlantic/Reykjavik,DJU,IS,Reydarf
 DKA,,Katsina,13.0057213,7.659455216289262,1617,http://www.faannigeria.org/nigeria-airport.php?airport=18,Africa/Lagos,DKA,NG,Katsina,Katsina,,AP
 DKI,YDKI,Dunk Island,-17.9371869,146.140759,49,,Australia/Brisbane,DKI,AU,,,,AP
 DKK,KDKK,Dunkirk,42.483334,-79.333336,590,,America/New_York,DKK,US,Dunkirk,New York,Chautauqua County,AP
-DKL,,Kiwigana Lodge Heliport,59.2416,-122.9222,1272,,America/Vancouver,DKL,CA,,,,AP
 DKR,GOOY,Leopold Sedar Senghor International Airport,14.73702885,-17.482709371575325,78,http://www.aeroportdakar.com/,Africa/Dakar,DKR,SN,Mermoz Boabab,Dakar,,AP
 DKS,UODD,Dikson,73.51668275,80.37453517180555,121,,Asia/Krasnoyarsk,DKS,RU,Dikson,Krasnoyarskiy,,AP
 DKV,YDVR,Docker River,-24.859699650000003,129.12215688442302,1896,,Australia/Darwin,DKV,AU,,,,AP
@@ -1926,7 +1904,6 @@ DLK,YDLK,Dulkaninna,-29.016666,139.46666,68,,Australia/Adelaide,DLK,AU,,,,AP
 DLL,KDLC,Dillon,34.416668,-79.36667,164,,America/New_York,DLL,US,Dillon,South Carolina,Dillon County,AP
 DLM,LTBS,Dalaman Airport,36.71183085,28.785783840398203,16,,Europe/Istanbul,DLM,TR,Dalaman,Mugla,,AP
 DLN,KDLN,Dillon,45.216667,-112.63333,5091,,America/Denver,DLN,US,Dillon,Montana,Beaverhead County,AP
-DLO,,Dolomi,55.122223,-132.05,0,,America/Sitka,DLO,US,,,,AP
 DLR,,Dalnerechensk Airport,45.8783,133.7363,282,,Asia/Vladivostok,DLR,RU,Dal'nerechensk,Primorskiy,,AP
 DLS,KDLS,Columbia Gorge Regional/The Dalles Municipal Airport,45.6,-121.166664,85,http://www.columbiagorgeairport.com/,America/Los_Angeles,DLS,US,The Dalles,Oregon,Wasco County,AP
 DLU,ZPDL,Dali Airport,25.6498551,100.31988697229497,7020,,Asia/Shanghai,DLU,CN,Dali,Yunnan,,AP
@@ -1947,7 +1924,6 @@ DMU,VEMR,Dimapur Airport,25.88526825,93.76774143023712,433,,Asia/Kolkata,DMU,IN,
 DNA,RODN,Kadena AB,26.3555999,127.7675,62,,Asia/Tokyo,OKA,JP,Okinawa,Okinawa,,AP
 DNB,YDBR,Dunbar,-16.010834,142.39055,177,,Australia/Brisbane,DNB,AU,,,,AP
 DND,EGPN,Dundee Airport,56.4526716,-3.026040420149899,22,http://www.hial.co.uk/dundee-airport.html,Europe/London,DND,GB,,,,AP
-DNE,,Dallas North Airport,32.75,-97.38333,656,,America/Chicago,DFW,US,Westworth,Texas,Tarrant County,AP
 DNF,,Martuba,32.55,22.766666,1026,,Africa/Tripoli,DNF,LY,Darnah,Darnah,,AP
 DNG,YDGN,Doongan,-15.3894937,126.2993393,1295,,Australia/Perth,DNG,AU,,,,AP
 DNH,ZLDH,Dunhuang Airport,40.2,94.683334,3704,,Asia/Shanghai,DNH,CN,,,,AP
@@ -1961,7 +1937,6 @@ DNP,VNDG,Dang,28.1121283,82.2903094,2027,,Asia/Kathmandu,DNP,NP,,,,AP
 DNQ,YDLQ,Deniliquin,-35.556630999999996,144.94788406467342,308,http://www.deniliquin.nsw.gov.au/index.php?option=com_content&view=article&id=46786:deniliquin-airport&catid=350&Itemid=1540,Australia/Sydney,DNQ,AU,Deniliquin,New South Wales,Deniliquin,AP
 DNR,LFRD,Pleurtuit Airport,48.587776,-2.083611,193,,Europe/Paris,DNR,FR,Pleurtuit,Brittany,Departement d'Ille-et-Vilaine,AP
 DNS,KDNS,Municipal,42.016666,-95.35,1266,http://www.denisonia.com/community/airport.asp,America/Chicago,DNS,US,Denison,Iowa,Crawford County,AP
-DNT,,Downtown Heliport,33.766666,-117.86667,78,,America/Los_Angeles,SNA,US,Santa Ana,California,Orange County,AP
 DNU,AYDN,Dinangat,-6.154976,146.67773660731413,5216,,Pacific/Port_Moresby,DNU,PG,,,,AP
 DNV,KDNV,Vermilion County,40.2003859,-87.59618325590233,672,http://vrairport.com/,America/Chicago,DNV,US,Danville,Illinois,Vermilion County,AP
 DNX,HSGG,Galegu,14.1,33.066666,1440,,Africa/Khartoum,DNX,SD,Kinana,Sinnar,,AP

--- a/airports.csv
+++ b/airports.csv
@@ -2461,7 +2461,6 @@ FRQ,AYFE,Feramin,-5.416667,141.7,5236,,Pacific/Port_Moresby,FRQ,PG,,,,AP
 FRR,KFRR,Front Royal-Warren County,38.91737455,-78.2547337875,682,,America/New_York,FRR,US,Front Royal,Virginia,Warren County,AP
 FRS,MGMM,Santa Elena Airport,16.916668,-89.88333,410,,America/Guatemala,FRS,GT,Flores,Peten,Municipio de Flores,AP
 FRT,SCEV,Frutillar,-41.129892,-73.06417233013931,479,,America/Santiago,FRT,CL,Frutillar,Los Lagos,Provincia de Llanquihue,AP
-FRU,UCFM,Manas International Airport,43.061389,74.4775,2090,,Asia/Bishkek,FRU,KG,Bishkek,Chuy,,AP
 FRW,FBFT,Francistown Airport,-21.15918875,27.471582024432315,3264,,Africa/Gaborone,FRW,BW,Francistown,North East,,AP
 FRY,KIZG,Fryeburg,43.9900665,-70.94755088747952,403,,America/New_York,FRY,US,Fryeburg,Maine,Oxford County,AP
 FRZ,ETHF,Fritzlar Airbase,51.11667,9.266667,570,,Europe/Berlin,FRZ,DE,Fritzlar,Hesse,,AP
@@ -7354,7 +7353,7 @@ SWH,YSWH,Swan Hill,-35.38333,143.61667,200,,Australia/Melbourne,SWH,AU,Swan Hill
 SWJ,NVSX,South West Bay,-16.25,167.16667,0,,Pacific/Efate,SWJ,VU,,,,AP
 SWL,RPSV,Spanish Wells,25.54,-76.75,45,,America/Nassau,SWL,BS,Spanish Wells,Spanish Wells,,AP
 SWM,,Suia-Missu,-11.216667,-53.25,895,,America/Cuiaba,SWM,BR,Sinop,Mato Grosso,Sinop,AP
-SWN,OPSW,Sahiwal,30.75,73.13333,508,,Asia/Karachi,SWN,PK,Sahiwal,Punjab,Sahiwal District,AP
+SWN,VISP,Sarsawa Airport,29.989555,77.408006,889,,Asia/Kolkata,SWN,IN,Sarsawa,Uttar Pradesh,Saharanpur,AP
 SWO,KSWO,Searcy Field,36.15889,-97.085556,954,http://stillwater.org/government/city_facilities/stillwater_regional_airport/,America/Chicago,SWO,US,Stillwater,Oklahoma,Payne County,AP
 SWP,FYSM,Swakopmund,-22.660858,14.5600131,190,,Africa/Windhoek,SWP,NA,,,,AP
 SWQ,WADS,Sultan Muhammad Kaharuddin III Airport,-8.5,117.416664,59,,Asia/Makassar,SWQ,ID,Karangbugis,West Nusa Tenggara,,AP

--- a/airports.csv
+++ b/airports.csv
@@ -2480,16 +2480,13 @@ FLP,KFLP,Flippin,36.292153,-92.587468,698,http://www.marioncountyairport.com/def
 FLR,LIRQ,Firenze-Peretola Airport,43.80928725,11.199120619746795,104,http://www.aeroporto.firenze.it/,Europe/Rome,FLR,IT,Sesto Fiorentino,Tuscany,Province of Florence,AP
 FLS,YFLI,Flinders Island Airport,-40.089789749999994,148.00199212585613,22,http://www.flinders.tas.gov.au/flinders-island-airport,Australia/Hobart,FLS,AU,Bridport,Tasmania,Dorset,AP
 FLT,FLT,Flat,62.4525,-157.9888889,328,,America/Anchorage,FLT,US,,,,AP
-FLU,,Flushing,40.775555,-73.83444,36,,America/New_York,NYC,US,,,,AP
 FLV,KFLV,Sherman AAF,39.36667,-94.916664,787,http://www.lvks.org/department/division.php?structureid=141,America/Chicago,FLV,US,Weston,Missouri,Platte County,AP
 FLW,LPFL,Santa Cruz Airport,39.466667,-31.15,383,,Atlantic/Azores,FLW,PT,,,,AP
 FLX,KFLX,Fallon Municipal Airport,39.49917,-118.74879,3960,,America/Los_Angeles,NFL,US,,,,AP
 FLY,YFIL,Finley,-35.65,145.58333,367,,Australia/Sydney,FLY,AU,,,,AP
 FLZ,WIMS,Ferdinand Lumban Tobing Airport,1.5584287,98.88774911868903,29,,Asia/Jakarta,FLZ,ID,Batangtoru,North Sumatra,,AP
 FMA,SARF,El Pucu Airport,-26.213222950000002,-58.22846252379796,127,,America/Argentina/Cordoba,FMA,AR,Formosa,Formosa,,AP
-FMC,,Five Mile,66.916664,-149.84166,4320,,America/Anchorage,FMC,US,,,,AP
 FME,KFME,Tipton AAF,39.103863,-76.84414,150,http://tiptonairport.org/,America/New_York,FME,US,Laurel,Maryland,Prince George's County,AP
-FMG,,Flamingo,10.416667,-85.78333,52,,America/Costa_Rica,FMG,CR,Sardinal,Guanacaste,,AP
 FMH,KFMH,Otis AFB,41.666668,-70.55,134,http://www.uscg.mil/d1/airstacapecod/,America/New_York,FMH,US,Forestdale,Massachusetts,Barnstable County,AP
 FMI,FZRF,Kalemie Airport,-5.8767486,29.245703687724784,2539,,Africa/Lubumbashi,FMI,CD,Kalemie,Katanga,,AP
 FMM,EDJA,Memmingen Allgau Airport,47.9892386,10.235409335315072,2060,,Europe/Berlin,FMM,DE,Memmingerberg,Bavaria,Swabia,AP
@@ -2508,7 +2505,6 @@ FNG,DFEF,Fada Ngourma,12.066667,0.35,948,,Africa/Ouagadougou,FNG,BF,Fada N'gourm
 FNH,HAFN,Fincha,9.583333,37.433334,5318,,Africa/Addis_Ababa,FNH,ET,Shambu,Oromiya,,AP
 FNI,LFTW,Garons Airport,43.75,4.416667,295,,Europe/Paris,FNI,FR,Garons,Languedoc-Roussillon,Departement du Gard,AP
 FNJ,ZKPY,Pyongyang Sunan International Airport,39.2295753,125.67704274664212,62,,Asia/Pyongyang,FNJ,KP,Sunan,Pyongyang,,AP
-FNK,,Fin Creek,69.5,-147.58333,836,,America/Anchorage,FNK,US,,,,AP
 FNL,KFNL,Municipalcipal Airport,40.583332,-105.083336,5039,http://www.flynoco.com/,America/Denver,FNL,US,,,,AP
 FNR,PANR,SPB,58.333332,-134.58333,114,,America/Juneau,FNR,US,,,,AP
 FNT,KFNT,Bishop International Airport,42.9607553,-83.74563177999201,777,,America/Detroit,FNT,US,Flint,Michigan,Genesee County,AP
@@ -2523,12 +2519,10 @@ FOK,KFOK,Suffolk County,40.833332,-72.666664,59,http://www.suffolkcountyny.gov/D
 FOM,FKKM,Foumban,5.75,10.833333,3881,,Africa/Douala,FOM,CM,Foumban,West,,AP
 FON,MRAN,Fortuna Airport,10.4,-84.48333,206,,America/Costa_Rica,FON,CR,Quesada,Alajuela,,AP
 FOO,WABF,Numfoor,-1.05,134.9,111,,Asia/Jayapura,FOO,ID,Kameri,Papua,,AP
-FOP,,Morris AAF,33.61667,-84.36667,971,,America/New_York,FOP,US,Forest Park,Georgia,Clayton County,AP
 FOR,SBFZ,Pinto Martins Airport,-3.779073,-38.540836,141,,America/Fortaleza,FOR,BR,Fortaleza,Ceara,Fortaleza,AP
 FOS,YFRT,Forrest,-30.816668,128.05,538,,Australia/Perth,FOS,AU,,,,AP
 FOT,YFST,Forster,-32.183334,151.51666,1266,,Australia/Sydney,FOT,AU,Dungog,New South Wales,Dungog,AP
 FOU,FOGF,Fougamou,-1.2,10.783333,931,,Africa/Libreville,FOU,GA,,,,AP
-FOX,,Fox,64.0,-147.0,3740,,America/Anchorage,FOX,US,Salcha,Alaska,Fairbanks North Star Borough,AP
 FOY,,Foya,8.3557615,-10.2274232,1440,,Africa/Monrovia,FOY,LR,Buedu,Eastern Province,,AP
 FPO,MYGF,Grand Bahama International Airport,26.556512750000003,-78.6955864137168,55,,America/Nassau,FPO,BS,Freeport,Freeport,,AP
 FPR,KFPR,St Lucie County,27.45,-80.333336,45,,America/New_York,FPR,US,Fort Pierce,Florida,Saint Lucie County,AP
@@ -2546,7 +2540,6 @@ FRL,LIPK,Luigi Ridolfi,44.195467199999996,12.067528607688963,68,,Europe/Rome,FRL
 FRM,KFRM,Fairmont,43.64722,-94.423615,1135,,America/Chicago,FRM,US,Fairmont,Minnesota,Martin County,AP
 FRN,PAFR,Bryant AAF,61.25,-149.68333,278,,America/Anchorage,FRN,US,Elmendorf Air Force Base,Alaska,Anchorage Municipality,AP
 FRO,ENFL,Flora Airport,61.58643,5.024577,29,https://avinor.no/en/airport/floro-airport/,Europe/Oslo,FRO,NO,Floro,Sogn og Fjordane,Flora,AP
-FRP,,Fresh Water Bay,57.845833,-135.025,0,,America/Juneau,FRP,US,,,,AP
 FRQ,AYFE,Feramin,-5.416667,141.7,5236,,Pacific/Port_Moresby,FRQ,PG,,,,AP
 FRR,KFRR,Front Royal-Warren County,38.91737455,-78.2547337875,682,,America/New_York,FRR,US,Front Royal,Virginia,Warren County,AP
 FRS,MGMM,Santa Elena Airport,16.916668,-89.88333,410,,America/Guatemala,FRS,GT,Flores,Peten,Municipio de Flores,AP
@@ -2561,7 +2554,6 @@ FSI,KFSI,Henry Post AAF,34.650723,-98.419975,1187,http://sill-www.army.mil/Histo
 FSK,KFSK,Municipal,37.833332,-94.7,846,http://www.fscity.org/index.php?option=com_content&view=article&id=98&Itemid=195,America/Chicago,FSK,US,Fort Scott,Kansas,Bourbon County,AP
 FSL,,Fossil Downs,-18.2,125.8,383,,Australia/Perth,FSL,AU,,,,AP
 FSM,KFSM,Fort Smith Regional Airport,35.3392525,-94.35697826263008,436,,America/Chicago,FSM,US,Barling,Arkansas,Sebastian County,AP
-FSN,,Haley AAF,42.15,-87.96667,669,,America/Chicago,FSN,US,Buffalo Grove,Illinois,Cook County,AP
 FSP,LFVP,Saint Pierre Airport,46.916668,-56.166668,0,,America/Miquelon,FSP,PM,Saint-Pierre,Saint-Pierre,,AP
 FSS,EGQK,Kinloss,57.65,-3.566667,36,,Europe/London,FSS,GB,Kinloss,Scotland,Moray,AP
 FST,KFST,Pecos County,30.893888,-102.87889,2969,,America/Chicago,FST,US,Fort Stockton,Texas,Pecos County,AP
@@ -2571,7 +2563,6 @@ FTA,NVVF,Futuna Airport,-19.416668,170.25,0,,Pacific/Efate,FTA,VU,,,,AP
 FTE,SAWC,El Calafate Airport,-50.28083645,-72.05064458669506,620,http://www.aeropuertoelcalafate.com/en/,America/Argentina/Rio_Gallegos,FTE,AR,,,,AP
 FTI,NSFQ,Fitiuta,-14.2161361,-169.42350846539222,82,,Pacific/Pago_Pago,FTI,AS,,,,AP
 FTK,KFTK,Godman AAF,37.9,-85.95,770,,America/Chicago,FTK,US,Fort Knox,Kentucky,Hardin County,AP
-FTL,,Fortuna Ledge,61.88333,-162.08333,78,,America/Nome,FTL,US,,,,AP
 FTU,FMSD,Marillac Airport,-25.04204875,46.95019958578181,32,,Indian/Antananarivo,FTU,MG,Fort Dauphin,Anosy,,AP
 FTW,KFTW,Meacham Field,32.75,-97.333336,636,http://meacham.com/,America/Chicago,FTW,US,,,,AP
 FTX,FCOO,Owando,-0.983333,16.008333,1059,,Africa/Brazzaville,FTX,CG,Owando,Cuvette,,AP
@@ -2592,9 +2583,7 @@ FVR,YFRV,Forrest River Airport,-15.253056,127.833336,396,,Australia/Perth,FVR,AU
 FWA,KFWA,Fort Wayne International Airport,40.9798288,-85.18791163159256,790,https://fwairport.com/,America/Indiana/Indianapolis,FWA,US,Ossian,Indiana,Wells County,AP
 FWH,KNFW,Fort Worth NAS Jrb/Carswell Field,32.76389,-97.3,577,http://www.cnic.navy.mil/regions/cnrse/installations/nas_jrb_fort_worth.html,America/Chicago,DFW,US,,,,AP
 FWL,PAFW,Farewell,62.50177185,-153.89687510043274,1492,,America/Anchorage,FWL,US,,,,AP
-FWM,,Heliport,56.816666,-5.116667,0,,Europe/London,FWM,GB,Fort William,Scotland,Highland,AP
 FXE,KFXE,Fort Lauderdale Executive Airport,26.066668,-80.15,22,http://www.fortlauderdale.gov/fxE/index.htm,America/New_York,FLL,US,Dania Beach,Florida,Broward County,AP
-FXM,,Flaxman Island,70.2,-146.0,0,,America/Anchorage,FXM,US,,,,AP
 FXO,FQCB,Cuamba,-14.817214400000001,36.53171848953477,1879,,Africa/Maputo,FXO,MZ,Cuamba,Niassa,,AP
 FXY,KFXY,Municipal,43.266666,-93.65,1276,http://www.cityofforestcity.com/departments/airport.asp,America/Chicago,FXY,US,Forest City,Iowa,Winnebago County,AP
 FYJ,ZYFY,Fuyuan Dongji Airport,48.199494,134.366447,167,,Asia/Shanghai,FYJ,CN,Fuyuan,Heilongjiang Sheng,,AP
@@ -2615,7 +2604,6 @@ GAG,KGAG,Gage,36.35,-99.88333,2404,,America/Chicago,GAG,US,Shattuck,Oklahoma,Ell
 GAH,YGAY,Gayndah,-25.433332,151.48334,465,,Australia/Brisbane,GAH,AU,Gayndah,Queensland,North Burnett,AP
 GAI,KGAI,Montgomery County,39.15,-77.2,505,http://www.montgomerycountyairpark.com/,America/New_York,GAI,US,Gaithersburg,Maryland,Montgomery County,AP
 GAJ,RJSC,Junmachi Airport,38.410645,140.36583,308,,Asia/Tokyo,GAJ,JP,Higashine,Yamagata,,AP
-GAK,,Gakona,62.333332,-145.31667,1758,,America/Anchorage,GAK,US,,,,AP
 GAL,PAGA,Edward G. Pitka Sr. Airport,64.73703425,-156.9332819814526,141,,America/Anchorage,GAL,US,,,,AP
 GAM,PAGM,Gambell Airport,63.7663034,-171.73268001027537,0,,America/Nome,GAM,US,,,,AP
 GAN,VRMG,Gan/Seenu Airport,-0.690003,73.15654,0,http://www.airports.com.mv/domestic/gan.htm,Indian/Maldives,GAN,MV,Hithadhoo,South Province,,AP
@@ -2644,10 +2632,8 @@ GBJ,TFFM,Les Bases,15.866667,-61.266666,0,,America/Guadeloupe,GBJ,GP,Grand-Bourg
 GBK,GFGK,Gbangbatok,7.81271795,-12.377632906257602,167,,Africa/Freetown,GBK,SL,Mogbwemo,Southern Province,,AP
 GBL,YGBI,Goulburn Island,-11.55,133.43333,0,,Australia/Darwin,GBL,AU,,,,AP
 GBM,,Garbaharey,3.3226676,42.2127663,715,,Africa/Mogadishu,GBM,SO,Garbahaarrey,Gedo,,AP
-GBO,,Baltimore Greenbelt T,39.266666,-76.75,501,,America/New_York,BWI,US,Catonsville,Maryland,Baltimore County,AP
 GBP,YGAM,Gamboola,-16.5434964,143.6696981,426,,Australia/Brisbane,GBP,AU,,,,AP
 GBR,KGBR,Walter J. Koladza Airport,42.18405305,-73.40333226677501,695,http://greatbarringtonairport.com/,America/New_York,GBR,US,Great Barrington,Massachusetts,Berkshire County,AP
-GBS,,Port Fitzroy,-36.13333,175.33333,45,,Pacific/Auckland,GBS,NZ,,,,AP
 GBT,OING,Gorgon Airport,36.90851,54.410515,-13,,Asia/Tehran,GBT,IR,Gorgan,Golestan,,AP
 GBU,HSKG,Khashm El Girba,14.9250002,35.8779984,1581,,Africa/Khartoum,GBU,SD,,,,AP
 GBV,YGIB,Gibb River,-15.65,126.63333,1167,,Australia/Perth,GBV,AU,,,,AP
@@ -2663,7 +2649,6 @@ GCK,KGCK,Garden City Municipal Airport,37.92861,-100.72972,2883,,America/Chicago
 GCM,MWCR,Owen Roberts International Airport,19.292621150000002,-81.35854363791051,32,,America/Cayman,GCM,KY,George Town,,,AP
 GCN,KGCN,National Park,35.951942,-112.1475,6591,http://www.azdot.gov/aviation/airports/airports_list.asp?FAA=GCN,America/Phoenix,GCN,US,,,,AP
 GCT,,Grand Canyon Bar 10 Airport,36.258,-113.2311,3933,,America/Phoenix,GCT,US,,,,AP
-GCV,,Gravatai,-29.941668,-50.994167,127,,America/Sao_Paulo,GCV,BR,Gravatai,Rio Grande do Sul,Gravatai,AP
 GCW,K1G4,Grand Canyon West,36.07211,-113.9495,4173,,America/Phoenix,GCW,US,Meadview,Arizona,Mohave County,AP
 GCY,KGCY,Municipal,36.216667,-82.85,1272,http://www.greenevilleaviation.com/,America/New_York,GCY,US,Greeneville,Tennessee,Greene County,AP
 GDA,,Gounda,9.333333,21.166668,1341,,Africa/Bangui,GDA,CF,,,,AP
@@ -2694,8 +2679,6 @@ GED,KGED,Sussex County,38.6898781,-75.35956548781664,72,https://www.sussexcounty
 GEE,YGTO,George Town,-18.283333,143.55,938,,Australia/Hobart,GEE,AU,,,,AP
 GEF,AGEV,Geva Airstrip,-7.578333,156.59778,160,,Pacific/Guadalcanal,GEF,SB,,,,AP
 GEG,KGEG,Spokane International Airport,47.620044050000004,-117.54236665513882,2342,http://www.spokaneairports.net/,America/Los_Angeles,GEG,US,Airway Heights,Washington,Spokane County,AP
-GEI,,Green Islands,-4.5,154.16667,78,,Pacific/Port_Moresby,GEI,PG,,,,AP
-GEK,,Ganes Creek,63.1,-156.43333,577,,America/Anchorage,GEK,US,,,,AP
 GEL,SBNM,Sepe Tiaraju,-28.28341965,-54.165611958794074,1013,,America/Sao_Paulo,GEL,BR,Santo Angelo,Rio Grande do Sul,Santo Angelo,AP
 GEM,FGMY,President Obiang Nguema International Airport,1.68179985,11.023465279817616,2234,,Africa/Malabo,GEM,GQ,Mongomo,Wele-Nzas,,AP
 GEO,SYCJ,Cheddi Jagan International Airport,6.498248800000001,-58.25592779458964,65,http://www.cjairport-gy.com/,America/Guyana,GEO,GY,Vreed-en-Hoop,Essequibo Islands-West Demerara,,AP
@@ -2706,8 +2689,6 @@ GEV,ESNG,Gallivare Airport,67.13180875,20.81734626236164,944,,Europe/Stockholm,G
 GEW,AYGC,Gewoia,-9.3,148.46666,3041,,Pacific/Port_Moresby,GEW,PG,,,,AP
 GEX,YGLG,Geelong,-38.13333,144.35,72,,Australia/Melbourne,GEX,AU,Geelong West,Victoria,Greater Geelong,AP
 GEY,KGEY,South Big Horn County,44.518039200000004,-108.083695988344,3904,http://www.bighorncountywy.gov/res-airports.htm,America/Denver,GEY,US,Greybull,Wyoming,Big Horn County,AP
-GFA,,Malmstrom AFB,47.5,-111.28333,3339,,America/Denver,GTF,US,,,,AP
-GFB,,Togiak Fish,59.016666,-160.05,173,,America/Anchorage,GFB,US,,,,AP
 GFD,KGFD,Pope Field,39.792199499999995,-85.73558027671119,843,,America/Indiana/Indianapolis,GFD,US,Greenfield,Indiana,Hancock County,AP
 GFE,YGNF,Grenfell,-33.9,148.18333,1374,,Australia/Sydney,GFE,AU,Grenfell,New South Wales,Weddin,AP
 GFF,YGTH,Griffith Airport,-34.252893349999994,146.06375907653336,383,,Australia/Sydney,GFF,AU,Griffith,New South Wales,Griffith,AP
@@ -2788,7 +2769,6 @@ GLM,YGLO,Glenormiston,-22.8901443,138.8210152,452,,Australia/Brisbane,GLM,AU,,,,
 GLN,GMAG,Goulimime Airport,29.016666,-10.066667,1023,,Africa/Casablanca,GLN,MA,Guelmim,Guelmim-Es Smara,Guelmim,AP
 GLO,EGBJ,Gloucestershire,51.88333,-2.233333,29,,Europe/London,GLO,GB,Gloucester,England,Gloucestershire,AP
 GLP,AYUP,Gulgubip,-5.283333,141.51666,4333,,Pacific/Port_Moresby,GLP,PG,,,,AP
-GLQ,,Glennallen,62.11667,-145.55,1433,,America/Anchorage,GLQ,US,,,,AP
 GLR,KGLR,Otsego County,45.0087112,-84.7023032695021,1299,http://www.gaylordregional.com/default.htm,America/Detroit,GLR,US,Gaylord,Michigan,Otsego County,AP
 GLS,KGLS,Scholes Field,29.2675,-94.860275,26,,America/Chicago,GLS,US,Galveston,Texas,Galveston County,AP
 GLT,YGLA,Gladstone Airport,-23.869519150000002,151.22385043997647,45,,Australia/Brisbane,GLT,AU,,,,AP
@@ -2835,7 +2815,6 @@ GOA,LIMJ,Genoa Cristoforo Colombo Airport,44.4127072,8.843503285615387,16,http:/
 GOB,HAGB,Goba,7.013889,39.980556,8832,,Africa/Addis_Ababa,GOB,ET,,,,AP
 GOC,AYGX,Gora,-9.166667,148.81667,88,,Pacific/Port_Moresby,GOC,PG,,,,AP
 GOE,AYGL,Gonalia,-5.366667,151.85,3146,,Pacific/Port_Moresby,GOE,PG,,,,AP
-GOF,,Goodfellow AFB,31.466667,-100.433334,1837,,America/Chicago,SJT,US,,,,AP
 GOG,FYGB,Gobabis,-22.5053774,18.97155062506426,4681,,Africa/Windhoek,GOG,NA,,,,AP
 GOH,BGGH,Nuuk Airport,64.1927724,-51.67788040878934,203,,America/Godthab,GOH,GL,Nuuk,Sermersooq,,AP
 GOI,VOGO,Dabolim Airport,15.380501500000001,73.8317012646639,141,,Asia/Kolkata,GOI,IN,Chicalim,Goa,South Goa,AP
@@ -2910,15 +2889,12 @@ GSS,FASE,Sabi Sabi,-25.116667,30.8,4215,,Africa/Johannesburg,GSS,ZA,Graksop,Mpum
 GST,PAGS,Gustavus Airport,58.423770649999994,-135.70631132484405,16,,America/Juneau,GST,US,,,,AP
 GSU,HSGF,Gedaref,14.033333,35.466667,2070,,Africa/Khartoum,GSU,SD,Al Qadarif,Al Qadarif,,AP
 GSV,,Saratov Gagarin Airport,51.716667,46.166667,82,,Europe/Saratov,RTW,RU,Shumeyka,Saratov,,AP
-GSY,,Binbrook,53.583332,-0.083333,0,,Europe/London,GSY,GB,Grimsby,England,North East Lincolnshire,AP
 GTA,AGOK,Gatokae Aerodrom,-8.766667,158.18333,823,,Pacific/Guadalcanal,GTA,SB,,,,AP
-GTB,,Genting,2.116667,111.7,22,,Asia/Kuala_Lumpur,GTB,MY,,,,AP
 GTC,,Green Turtle,26.25,-77.36667,0,,America/Nassau,GTC,BS,Hard Bargain,Moore's Island,,AP
 GTE,YGTE,Alyangula Airport,-13.973887,136.46002,39,,Australia/Darwin,GTE,AU,,,,AP
 GTF,KGTF,Great Falls International Airport,47.4800263,-111.37557897482165,3664,,America/Denver,GTF,US,Great Falls,Montana,Cascade County,AP
 GTG,KGTG,Municipal,45.783333,-92.683334,921,http://www.grantsburgwi.com/airport.html,America/Chicago,GTG,US,Grantsburg,Wisconsin,Burnett County,AP
 GTI,EDCG,Guettin,54.38333,12.316667,0,,Europe/Berlin,GTI,DE,Ostseebad Dierhagen,Mecklenburg-Vorpommern,,AP
-GTK,,Sungei Tekai,2.6,102.916664,154,,Asia/Kuala_Lumpur,GTK,MY,Segamat,Johor,,AP
 GTN,NZGT,Glentanner,-43.766666,170.13611,2122,,Pacific/Auckland,MON,NZ,,,,AP
 GTO,WAMG,Tolotio Airport,0.639039,122.850876,121,,Asia/Makassar,GTO,ID,Isimu,Gorontalo,,AP
 GTP,KSXT,Grants Pass,42.5101682,-123.3885181,1079,,America/Los_Angeles,GTP,US,Merlin,Oregon,Josephine County,AP
@@ -2940,7 +2916,6 @@ GUI,SVGI,Guiria,10.5764238,-62.31121093515691,65,,America/Caracas,GUI,VE,Gueiria
 GUJ,SBGW,Guaratingueta,-22.791205050000002,-45.20482610775648,1748,,America/Sao_Paulo,GUJ,BR,Guaratingueta,Sao Paulo,Guaratingueta,AP
 GUL,YGLB,Goulburn,-34.75,149.71666,2080,,Australia/Sydney,GUL,AU,Goulburn,New South Wales,Goulburn Mulwaree,AP
 GUM,PGUM,A.B. Won Pat International Airport,13.492787,144.80486,282,http://www.guamairport.com/,Pacific/Guam,GUM,GU,Tamuning-Tumon-Harmon Village,Tamuning,,AP
-GUN,,Gunter AFB,32.38333,-86.316666,167,,America/Chicago,MGM,US,,,,AP
 GUO,MHJI,Gualaco,15.116667,-86.13333,2152,,America/Tegucigalpa,GUO,HN,Gualaco,Olancho,,AP
 GUP,KGUP,Senator Clark,35.511112,-108.78667,6463,,America/Denver,GUP,US,Gallup,New Mexico,McKinley County,AP
 GUQ,SVGU,Guanare,9.02806755,-69.75436356069964,531,,America/Caracas,GUQ,VE,Guanare,Portuguesa,Municipio Guanare,AP

--- a/airports.csv
+++ b/airports.csv
@@ -4512,7 +4512,6 @@ LEC,SBLE,Coronel Horacio de Mattos Airport,-12.48,-41.281113,1676,,America/Bahia
 LED,ULLI,Pulkovo Airport,59.801698599999995,30.267601113109503,78,http://www.pulkovoairport.ru/,Europe/Moscow,LED,RU,Dachnoye,St.-Petersburg,,AP
 LEE,KLEE,Leesburg,28.833332,-81.816666,76,http://www.leesburgflorida.gov/index.aspx?page=45,America/New_York,LEE,US,Silver Lake,Florida,Lake County,AP
 LEF,FXLK,Lebakeng,-29.783333,28.583332,6000,,Africa/Maseru,LEF,LS,,,,AP
-LEG,,Aleg,17.166668,-13.95,0,,Africa/Nouakchott,LEG,MR,,,,AP
 LEH,LFOH,Octeville,49.534665,0.0904336239438063,313,,Europe/Paris,LEH,FR,Sainte-Adresse,Haute-Normandie,Departement de la Seine-Maritime,AP
 LEI,LEAM,Almeria Airport,36.84399365,-2.3719995931572844,70,http://www.aena.es/csee/Satellite?cid=1048146844127&pagename=subHome&Language=EN_GB&SiteName=LEI&c=Page,Europe/Madrid,LEI,ES,Retamar,Andalusia,Provincia de Almeria,AP
 LEJ,EDDP,Leipzig/Halle Airport,51.421190100000004,12.229585904866344,465,http://www.leipzig-halle-airport.de/en/index.html,Europe/Berlin,LEJ,DE,,,,AP
@@ -4569,7 +4568,6 @@ LGX,HCMJ,Lugh Ganane,3.8,42.05,507,,Africa/Mogadishu,LGX,SO,,,,AP
 LGY,,Lagunillas,8.516667,-71.4,2469,,America/Caracas,LGY,VE,Lagunillas,Merida,Municipio Sucre,AP
 LGZ,ZUSH,Shannan Longzi Airport,28.4225,92.344444,13058,,Asia/Shanghai,LGZ,CN,Shannan,,,AP
 LHA,EDTL,Black Forest,48.333332,7.883333,511,http://airport-lahr.de/,Europe/Berlin,LHA,DE,Lahr,Baden-Wuerttemberg,Freiburg Region,AP
-LHB,,Lost Harbor Sea Port,54.233334,-165.6,0,,America/Nome,LHB,US,,,,AP
 LHE,OPLA,Allama Iqbal International Airport,31.51939965,74.40099966094238,712,,Asia/Karachi,LHE,PK,Lahore,Punjab,,AP
 LHG,YLRD,Lightning Ridge,-29.4531612,147.980323605421,540,,Australia/Sydney,LHG,AU,,,,AP
 LHI,WAJL,Lereh,-3.133333,139.9,820,,Asia/Jayapura,LHI,ID,Genyem,Papua,,AP
@@ -4606,7 +4604,6 @@ LIX,FWLK,Likoma,-12.07947195,34.736307856169844,1600,,Africa/Blantyre,LIX,MW,Chi
 LIY,KLHW,Wright AAF,31.85,-81.6,45,,America/New_York,LIY,US,Hinesville,Georgia,Liberty County,AP
 LIZ,ME16,Loring AFB,42.033333,-78.63333,746,,America/New_York,LIZ,US,Foster Brook,Pennsylvania,McKean County,AP
 LJA,FZVA,Lodja,-3.397222,23.444445,1647,,Africa/Lubumbashi,LJA,CD,Lodja,Kasai-Oriental,,AP
-LJC,,Intercontinental,36.266666,-85.75,0,,America/Kentucky/Louisville,SDF,US,Lafayette,Tennessee,Putnam County,AP
 LJG,ZPLJ,Lijiang Airport,26.67695645,100.24519087992596,0,,Asia/Shanghai,LJG,CN,Huangshan,Yunnan,,AP
 LJN,KLJN,Brazoria County,29.038334,-95.45695,25,http://www.flylbx.org/,America/Chicago,LJN,US,Lake Jackson,Texas,Brazoria County,AP
 LJU,LJLJ,Ljubljana Joze Pucnik Airport,46.22247455,14.463847697380164,1273,http://www.lju-airport.si/,Europe/Ljubljana,LJU,SI,Sencur,Sencur,,AP
@@ -4625,7 +4622,6 @@ LKN,ENLK,Leknes Airport,68.1528581,13.610591306639233,78,https://avinor.no/en/ai
 LKO,VILK,Chaudhary Charan Singh International Airport,26.7584263,80.87779945060207,410,http://aai.aero/allAirports/lucknow_generalinfo.jsp,Asia/Kolkata,LKO,IN,Lucknow,Uttar Pradesh,Lucknow District,AP
 LKP,KLKP,Lake Placid,44.2649482,-73.96449549652145,1747,,America/New_York,LKP,US,Lake Placid,New York,Essex County,AP
 LKR,,Las Khoreh,11.1707986,48.2080558,0,,Africa/Mogadishu,LKR,SO,Las Khorey,Sanaag,,AP
-LKS,,Lakeside,30.500834,-98.14694,0,,America/Chicago,LKS,US,Briarcliff,Texas,Travis County,AP
 LKU,,Lake Rudolf,3.416667,35.8833313,1300,,Africa/Nairobi,LKU,KE,,,,AP
 LKV,KLKV,Lake County,42.166668,-120.4,4733,http://www.lakecountyor.org/government/airport/index.php,America/Los_Angeles,LKV,US,Lakeview,Oregon,Lake County,AP
 LKW,OOLK,Lekhwair,22.80543685,55.37312130426234,354,,Asia/Muscat,LKW,OM,`Ibri,Az Zahirah,,AP
@@ -4648,7 +4644,6 @@ LLO,WAFD,Bua Airport,-3.0777591,120.24361440556194,13,,Asia/Makassar,LLO,ID,Beri
 LLP,,Linda Downs,-23.166668,138.7,0,,Australia/Brisbane,LLP,AU,,,,AP
 LLS,SATK,Las Lomitas,-24.7261244,-60.5495104,426,,America/Argentina/Cordoba,LLS,AR,Las Lomitas,Formosa,,AP
 LLT,,Lobito,-12.3711467,13.538592590764758,0,,Africa/Luanda,LLT,AO,Lobito,Benguela,,AP
-LLU,,Alluitsup Paa,60.46417,-45.56889,0,,America/Godthab,LLU,GL,,,,AP
 LLV,ZBLL,Lüliang Airport,37.683333,111.142778,0,,Asia/Shanghai,LLV,CN,Lishi,Shanxi Sheng,Lueliang,AP
 LLW,FWKI,Lilongwe International Airport,-13.7886661,33.78211495665334,4035,,Africa/Blantyre,LLW,MW,Lilongwe,Central Region,Lilongwe District,AP
 LLX,KCDA,Lyndonville,44.5,-72.01667,1188,,America/New_York,LLX,US,Lyndon,Vermont,Caledonia County,AP
@@ -4705,7 +4700,6 @@ LOC,YLOK,Lock,-33.55,135.75,413,,Australia/Adelaide,LOC,AU,,,,AP
 LOD,NVSG,Longana,-15.3061063,167.96903185,82,,Pacific/Efate,LOD,VU,,,,AP
 LOE,VTUL,Loei Airport,17.4442856,101.724971,823,,Asia/Bangkok,LOE,TH,Loei,Loei,,AP
 LOF,,Loen,7.916667,169.91667,23,,Pacific/Majuro,LOF,MH,Jabat,Jabat Island,,AP
-LOG,,Longview,46.11667,-122.88333,141,,America/Los_Angeles,LOG,US,Kelso,Washington,Cowlitz County,AP
 LOH,SETM,Ciudad de Catamayo Airport,-3.993611,-79.37361,3943,,America/Guayaquil,LOH,EC,Catamayo,Loja,,AP
 LOI,SSLN,Helmuth Baungartem,-27.159721,-49.542778,1062,,America/Sao_Paulo,LOI,BR,Ibirama,Santa Catarina,Ibirama,AP
 LOK,HKLO,Lodwar Airport,3.12213865,35.60945590645913,1633,,Africa/Nairobi,LOK,KE,,,,AP
@@ -4714,7 +4708,6 @@ LOM,,Francisco P. V. Y R.,21.266666,-101.933334,6151,,America/Mexico_City,LOM,MX
 LOO,DAUL,L'Mekrareg Airport,33.833332,2.983333,2490,,Africa/Algiers,LOO,DZ,Laghouat,Laghouat,,AP
 LOP,WADL,Lombok International Airport,-8.759159499999999,116.2710722149254,357,http://www.lombok-airport.co.id/,Asia/Makassar,LOP,ID,Tanakawu Dua,West Nusa Tenggara,,AP
 LOQ,FBLO,Lobatse,-25.1982784,25.7136876,3756,,Africa/Gaborone,LOQ,BW,Lobatse,South East,,AP
-LOR,,Lowe Army Heliport,31.5,-85.433334,354,,America/Chicago,OZR,US,Headland,Alabama,Henry County,AP
 LOS,DNMM,Murtala Muhammed International Airport,6.577871,3.321178,177,http://www.faannigeria.org/nigeria-airport.php?airport=1,Africa/Lagos,LOS,NG,Oshodi,Lagos,,AP
 LOT,KLOT,Lewis Lockport,41.583332,-88.05,662,http://www.flylot.com/,America/Chicago,LOT,US,Lockport,Illinois,Will County,AP
 LOU,KLOU,Bowman Field Airport,38.266666,-85.75,429,http://www.flylouisville.com/bowman-field/fast-facts/,America/Kentucky/Louisville,SDF,US,Louisville,Kentucky,Jefferson County,AP
@@ -4742,7 +4735,6 @@ LPQ,VLLB,Luang Prabang International Airport,19.90650995,102.16998023046885,958,
 LPS,S31,Lopez Island,48.4845639,-122.937472,68,,America/Los_Angeles,LPS,US,,,,AP
 LPT,VTCL,Lampang Airport,18.2782787,99.5053516,810,,Asia/Bangkok,LPT,TH,Lampang,Lampang,,AP
 LPU,WALP,Long Apung,1.7056919499999998,114.97093738508752,2086,,Asia/Makassar,LPU,ID,Longnawang,North Kalimantan,,AP
-LPW,,Little Port Walter,56.38333,-134.83333,1784,,America/Sitka,LPW,US,,,,AP
 LPX,EVLA,Liepaya Airport,56.516666,21.1,19,http://www.liepaja-airport.lv/,Europe/Riga,LPX,LV,Grobina,Grobina,,AP
 LPY,LFHP,Loudes Airport,45.083332,3.766667,2660,,Europe/Paris,LPY,FR,Saint-Paulien,Auvergne,Departement de la Haute-Loire,AP
 LQK,KLQK,Pickens,34.88333,-82.7,1102,http://www.co.pickens.sc.us/Pickens%20County%20Airport/default.aspx,America/New_York,LQK,US,Pickens,South Carolina,Pickens County,AP
@@ -4757,11 +4749,8 @@ LRG,OPLL,Lora Lai,27.85,65.083336,2634,,Asia/Karachi,LRG,PK,Kharan,Balochistan,,
 LRH,LFBH,Laleu Airport,46.180557,-1.185833,68,,Europe/Paris,LRH,FR,Nieul-sur-Mer,Poitou-Charentes,Departement de la Charente-Maritime,AP
 LRI,,Lorica,9.033333,-75.7,39,,America/Bogota,LRI,CO,Cotorra,Cordoba,,AP
 LRJ,KLRJ,Municipal,42.8,-96.166664,1187,http://www.lemarsiowa.com/citygov/airport.htm,America/Chicago,LRJ,US,Le Mars,Iowa,Plymouth County,AP
-LRK,,Coast Guard,-16.12,-68.32,17011,,America/Sitka,LRK,US,Batallas,La Paz,,AP
 LRL,DXNG,Niamtougou,9.833333,1.133333,1394,,Africa/Lome,LRL,TG,Niamtougou,Kara,,AP
 LRM,MDLR,La Romana Airport,18.416668,-68.9,131,,America/Santo_Domingo,LRM,DO,La Romana,La Romana,,AP
-LRN,,Larson AFB,47.13333,-119.28333,1053,,America/Los_Angeles,MWH,US,Moses Lake,Washington,Grant County,AP
-LRO,,Sharpe AAF,39.55,-94.333336,1066,,America/Los_Angeles,LRO,US,Lathrop,Missouri,Clinton County,AP
 LRQ,CJC8,Laurie River,56.216667,-101.0,921,,America/Winnipeg,LRQ,CA,,,,AP
 LRR,OISL,Lar Airport,27.66969,54.38276,2634,,Asia/Tehran,LRR,IR,Lar,Fars,,AP
 LRS,LGLE,Leros Airport,37.516666,26.783333,0,,Europe/Athens,LRS,GR,Megalo Chorio,South Aegean,,AP
@@ -4771,7 +4760,6 @@ LRV,SVRS,Los Roques,11.833333,-66.75,0,,America/Caracas,LRV,VE,Caraballeda,Varga
 LSA,AYKA,Losuia,-8.363889,151.025,0,,Pacific/Port_Moresby,LSA,PG,,,,AP
 LSB,KLSB,Lordsburg,32.416668,-108.666664,4396,,America/Denver,LSB,US,Lordsburg,New Mexico,Hidalgo County,AP
 LSC,SCSE,La Florida Airport,-29.915545950000002,-71.20194424333569,469,,America/Santiago,LSC,CL,La Serena,Coquimbo,Provincia de Elqui,AP
-LSD,,Blue Grass Station Army Heliport,38.0317136,-84.4951359,1000,,America/New_York,LEX,US,Mount Vernon,Kentucky,Fayette County,AP
 LSE,KLSE,La Crosse Regional Airport,43.878607,-91.25557153542314,587,http://www.lseairport.com/,America/Chicago,LSE,US,French Island,Wisconsin,La Crosse County,AP
 LSF,KLSF,Lawson AAF,32.3405,-84.986046,236,,America/New_York,LSF,US,,,,AP
 LSH,VYLS,Lashio,22.980234000000003,97.75089767599788,2493,,Asia/Rangoon,LSH,MM,,,,AP
@@ -4799,7 +4787,6 @@ LTC,FTTH,Lai,9.416667,16.3,1141,,Africa/Ndjamena,LTC,TD,Lai,Tandjile,,AP
 LTD,HLTD,Ghadames,30.129168,9.509722,1059,,Africa/Tripoli,LTD,LY,Ghadamis,Sha`biyat Nalut,,AP
 LTF,,Leitre,-2.8333213,141.62480460905633,29,,Pacific/Port_Moresby,LTF,PG,Leitre,Sandaun,,AP
 LTG,VNLT,Langtang,28.233334,85.6,16332,,Asia/Kathmandu,LTG,NP,Chongdui,Tibet Autonomous Region,,AP
-LTH,,Lathrop Wells,36.6346755,-116.4133813,2595,,America/Los_Angeles,LTH,US,,,,AP
 LTI,ZMAT,Altai,46.65,96.416664,6250,,Asia/Hovd,LTI,MN,Tsagaan-Olom,Govi-Altay,,AP
 LTK,OSLK,Latakia,35.40183425,35.950402853728235,59,,Asia/Damascus,LTK,SY,Jablah,Latakia,,AP
 LTL,FOOR,Lastourville,-0.8260877,12.7471516,1515,,Africa/Libreville,LTL,GA,Lastoursville,Ogooue-Lolo,,AP
@@ -4964,12 +4951,10 @@ MCI,KMCI,Kansas City International Airport,39.3023103,-94.72118991743454,977,htt
 MCJ,SKLM,Maicao,11.3890982,-72.2424609,127,,America/Bogota,MCJ,CO,Maicao,La Guajira,,AP
 MCK,KMCK,Mc Cook Airport,40.26389,-100.66805,2657,,America/Chicago,MCK,US,McCook,Nebraska,Red Willow County,AP
 MCL,PAIN,Mt Mckinley,63.875973,-149.0064,1437,,America/Anchorage,MCL,US,,,,AP
-MCM,,Fontvieille Heliport,43.733334,7.416667,229,,Europe/Monaco,MCM,MC,Monaco,Commune de Monaco,,AP
 MCN,KMCN,Lewis B Wilson,32.70199,-83.64865,377,,America/New_York,MCN,US,,,,AP
 MCO,KMCO,Orlando International Airport,28.412903550000003,-81.30944309752753,82,http://www.orlandoairports.net/,America/New_York,ORL,US,Taft,Florida,Orange County,AP
 MCP,SBMQ,Macapa International Airport,0.0505785,-51.07059996039651,42,,America/Belem,MCP,BR,Macapa,Amapa,Macapa,AP
 MCQ,LHMC,Miskolc,48.1377737,20.789699376565146,406,http://www.lhmc.hu/,Europe/Budapest,MCQ,HU,Arnot,Borsod-Abauj-Zemplen,,AP
-MCR,,Melchor De Menco,17.0,-92.00833,4455,,America/Guatemala,MCR,GT,Chiquinival,Chiapas,Chilon,AP
 MCS,SARM,Monte Caseros,-30.26812535,-57.640830221297385,55,,America/Argentina/Cordoba,MCS,AR,Monte Caseros,Corrientes,Departamento de Monte Caseros,AP
 MCT,OOMS,Muscat International Airport,23.599458,58.29212963328453,49,,Asia/Muscat,MCT,OM,Bawshar,Muhafazat Masqat,,AP
 MCU,LFBK,Gueret (Lepaud),46.35,2.6,652,,Europe/Paris,MCU,FR,Montlucon,Auvergne,Departement de l'Allier,AP
@@ -4978,7 +4963,6 @@ MCW,KMCW,Mason City Airport,43.156944,-93.329445,1197,,America/Chicago,MCW,US,Cl
 MCX,URML,Makhachkala Airport,42.816631900000004,47.65567236459954,3,,Europe/Moscow,MCX,RU,Kaspiysk,Dagestan,,AP
 MCY,YBSU,Sunshine Coast Airport,-26.59467215,153.0834615909481,45,http://www.sunshinecoastairport.com.au/,Australia/Brisbane,MCY,AU,Coolum Beach,Queensland,Sunshine Coast,AP
 MCZ,SBMO,Maceio-Zumbi dos Palmares International Airport,-9.512521,-35.800446,321,,America/Maceio,MCZ,BR,Satuba,Alagoas,Satuba,AP
-MDA,KMDA,Martindale Army Heliport,29.4312992,-98.3778,672,,America/Chicago,SAT,US,San Antonio,Texas,,AP
 MDB,,Melinda,16.998611,-88.32056,104,,America/Belize,MDB,BZ,Dangriga,Stann Creek,Dangriga,AP
 MDC,WAMM,Sam Ratulangi International Airport,1.5504688500000001,124.92516459750878,282,,Asia/Makassar,MDC,ID,Tatelu,North Sulawesi,,AP
 MDD,KMDD,Airpark,32.0,-102.05,2759,,America/Chicago,MAF,US,Midland,Texas,Midland County,AP
@@ -5049,7 +5033,6 @@ MFP,YMCR,Manners Creek,-22.09844175,137.98517638728612,656,,Australia/Darwin,MFP
 MFQ,DRRM,Maradi,13.50119435,7.124447553561355,1181,,Africa/Niamey,MFQ,NE,Maradi,Maradi,,AP
 MFR,KMFR,Rogue Valley International-Medford Airport,42.3727441,-122.87342921752662,1282,,America/Los_Angeles,MFR,US,Medford,Oregon,Jackson County,AP
 MFS,SKMF,Miraflores,5.166667,-73.25,10387,,America/Bogota,MFS,CO,Miraflores,Boyaca,,AP
-MFT,,Machu Picchu,-13.116667,-72.566666,9767,,America/Lima,MFT,PE,Santa Teresa,Cusco,Provincia de La Convencion,AP
 MFU,FLMF,Mfuwe,-13.25844945,31.942546721089855,1820,,Africa/Lusaka,MFU,ZM,Chipata,Eastern,,AP
 MFV,KMFV,Accomack County,37.64691175,-75.76022473099388,49,http://www.co.accomack.va.us/departments/airport,America/New_York,MFV,US,Onancock,Virginia,Accomack County,AP
 MFW,,Magaruque,-21.972221,35.591667,0,,Africa/Maputo,MFW,MZ,,,,AP
@@ -5083,7 +5066,6 @@ MGX,FOGI,Moabi,-2.25,11.0,1059,,Africa/Libreville,MGX,GA,,,,AP
 MGY,KMGY,Dayton-Wright Brothers Airport,39.933334,-84.25444,938,http://www.flydayton.com/?page=wright-brothers-airport-2,America/New_York,DAY,US,Union,Ohio,Montgomery County,AP
 MGZ,VYME,Myeik Airport,12.4397928,98.62146561643826,36,,Asia/Rangoon,MGZ,MM,Myeik,Tanintharyi,,AP
 MHA,SYMD,Mahdia,5.27323,-59.14942234096078,282,,America/Guyana,MHA,GY,,,,AP
-MHB,,Mechanics Bay,-36.845,174.78473,42,,Pacific/Auckland,AKL,NZ,,,,AP
 MHC,SCPQ,Mocopulli Airport,-42.341692,-73.71585344124517,544,,America/Santiago,WCA,CL,,,,AP
 MHD,OIMM,Mashhad International Airport,36.23409075,59.641866810223185,3248,,Asia/Tehran,MHD,IR,Mashhad,Razavi Khorasan,,AP
 MHE,KMHE,Municipal,43.775276,-98.038055,1312,http://www.cityofmitchell.org/index.asp?SEC=0E5EB6F8-1E38-48AD-8D27-2CDD01C4E949&Type=B_BASIC,America/Chicago,MHE,US,Mitchell,South Dakota,Davison County,AP
@@ -5138,7 +5120,6 @@ MJC,DIMN,Man,7.381667,-7.528333,1082,,Africa/Abidjan,MJC,CI,Man,Dix-Huit Montagn
 MJD,OPMJ,Mohenjodaro,27.334915350000003,68.14136891196353,147,,Asia/Karachi,MJD,PK,Dokri,Sindh,,AP
 MJE,,Majkin,9.0,170.0,0,,Pacific/Majuro,MJE,MH,,,,AP
 MJF,ENMS,Kjaerstad Airport,65.78439,13.218328,177,https://avinor.no/en/airport/mosjoen-airport/,Europe/Oslo,MJF,NO,Mosjoen,Nordland,Vefsn,AP
-MJG,,Mayajigua,21.758333,-79.0,167,,America/Havana,MJG,CU,Venezuela,Ciego de Avila,,AP
 MJI,HLLM,Mitiga Tripoli Airport,32.89722,13.277778,26,,Africa/Tripoli,TIP,LY,Tagiura,Tripoli,,AP
 MJJ,,Moki,-5.7,145.25,4520,,Pacific/Port_Moresby,MJJ,PG,,,,AP
 MJK,YSHK,Shark Bay,-25.8975961,113.57594702287881,200,,Australia/Perth,MJK,AU,,,,AP
@@ -5223,7 +5204,6 @@ MMN,,Minute Man Airfield,42.460355899999996,-71.51801357130509,226,,America/New_
 MMO,GVMA,Vila Do Maio,15.25,-23.166668,95,,Atlantic/Cape_Verde,MMO,CV,Vila do Maio,Maio,,AP
 MMP,,Mompos,9.257874650000002,-74.43841678209353,65,,America/Bogota,MMP,CO,Mompos,Bolivar,,AP
 MMQ,FLBA,Mbala,-8.8596105,31.33412808987253,5488,,Africa/Lusaka,MMQ,ZM,Mbala,Northern,,AP
-MMR,,Camp Maybry AHP,30.283333,-97.75,547,,America/Chicago,AUS,US,Austin,Texas,Travis County,AP
 MMS,KMMS,Selfs,34.2315002,-90.2895376,141,,America/Chicago,MMS,US,Marks,Mississippi,Quitman County,AP
 MMT,KMMT,Mc Entire ANG Base,33.93667,-81.115555,190,,America/New_York,CAE,US,Springdale,South Carolina,Lexington County,AP
 MMU,KMMU,Morristown Municipal Airport,40.79980845,-74.42250940675584,167,,America/New_York,MMU,US,Florham Park,New Jersey,Morris County,AP
@@ -5287,13 +5267,10 @@ MPA,FYKM,Mpacha,-17.5,24.266666,3097,,Africa/Windhoek,MPA,NA,,,,AP
 MPB,X44,Miami Sea Plane Base,25.75,-80.166664,0,,America/New_York,MIA,US,,,,AP
 MPC,WIPU,Muko-Muko,-2.55,101.1,36,,Asia/Jakarta,MPC,ID,Sungai Penuh,Jambi,,AP
 MPD,OPMP,Mirpur Khas,25.65,69.03333,45,,Asia/Karachi,MPD,PK,Mirpur Khas,Sindh,,AP
-MPE,,Griswold,41.283333,-72.6,55,,America/New_York,MPE,US,Madison,Connecticut,New Haven County,AP
 MPF,AYPO,Mapoda,-7.966667,143.16667,13,,Pacific/Port_Moresby,MPF,PG,,,,AP
 MPG,AYMJ,Makini,-6.533333,147.71666,1233,,Pacific/Port_Moresby,MPG,PG,,,,AP
 MPH,RPVE,Boracay Airport,11.92508925,121.95266939156987,26,,Asia/Manila,MPH,PH,Caticlan,Western Visayas,Province of Aklan,AP
 MPI,,Mamitupo,9.578333,-79.843056,0,,America/Panama,MPI,PA,Maria Chiquita,Colon,,AP
-MPJ,,Petit Jean Park,35.15,-92.73333,377,,America/Chicago,MPJ,US,Morrilton,Arkansas,Conway County,AP
-MPK,,Mokpo,34.75862305,126.38050579713945,26,,Asia/Seoul,MPK,KR,Moppo,Jeollanam-do,,AP
 MPL,LFMT,Montpellier Mediterranee Airport,43.578799000000004,3.9593453999962533,22,,Europe/Paris,MPL,FR,Perols,Languedoc-Roussillon,Departement de l'Herault,AP
 MPM,FQMA,Maputo International Airport,-25.9063936,32.582643793413375,78,,Africa/Maputo,MPM,MZ,,,,AP
 MPN,EGYP,Mount Pleasant,-51.8208456,-58.4564927,177,,Atlantic/Stanley,MPN,FK,,,,AP
@@ -5317,7 +5294,6 @@ MQE,YMQA,Marqua,-22.816668,137.35,734,,Australia/Darwin,MQE,AU,,,,AP
 MQF,USCM,Magnitogorsk Airport,53.45,59.066666,1279,,Asia/Yekaterinburg,MQF,RU,Magnitogorsk,Chelyabinsk,Gorod Magnitogorsk,AP
 MQG,FYMG,Midgard,-22.083332,17.366667,5203,,Africa/Windhoek,MQG,NA,Okahandja,Otjozondjupa,,AP
 MQH,SWIQ,Municipal,-13.533333,-48.233334,1312,,America/Sao_Paulo,MQH,BR,Cavalcante,Goias,Cavalcante,AP
-MQI,,Quincy,42.25,-71.0,62,,America/New_York,MQI,US,Quincy,Massachusetts,Norfolk County,AP
 MQJ,UEMA,Moma,66.4511768,143.25843906288407,613,,Asia/Srednekolymsk,MQJ,RU,,,,AP
 MQK,SLTI,San Matias,-16.3391991,-58.4019012,419,,America/La_Paz,MQK,BO,San Matias,Santa Cruz,,AP
 MQL,YMIA,Mildura Airport,-34.23063835,142.08837740764827,124,http://www.milduraairport.com.au/,Australia/Melbourne,MQL,AU,Mildura,Victoria,Mildura Shire,AP
@@ -5362,7 +5338,6 @@ MRX,OIAM,Mahshahr Airport,30.56090975,49.14683456086563,39,,Asia/Tehran,MRX,IR,B
 MRY,KMRY,Monterey Regional Airport,36.58705795,-121.84193978436595,209,,America/Los_Angeles,MRY,US,Del Rey Oaks,California,Monterey County,AP
 MRZ,YMOR,Moree Airport,-29.4939246,149.8512411,702,,Australia/Sydney,MRZ,AU,Moree,New South Wales,Moree Plains,AP
 MSA,CZMD,Muskrat Dam,53.816666,-91.98333,869,,America/Winnipeg,MSA,CA,,,,AP
-MSB,,Marigot SPB,18.066668,-63.066666,285,,America/Marigot,SFG,MF,,,,AP
 MSC,KFFZ,Falcon Field,33.416668,-111.833336,1230,http://www.falconfieldairport.com/,America/Phoenix,MSC,US,Mesa,Arizona,Maricopa County,AP
 MSD,,Mt Pleasant,39.524723,-111.47444,5853,,America/Denver,MSD,US,Mount Pleasant,Utah,Sanpete County,AP
 MSE,EGMH,Kent International,51.35,1.35,121,http://www.kentinternationalairport-manston.com/,Europe/London,MSE,GB,Westgate on Sea,England,Kent,AP
@@ -6890,7 +6865,6 @@ RKV,BIRK,Reykjavik International Airport,64.13106,-21.932476,32,,Atlantic/Reykja
 RKW,KRKW,Rockwood Municipal Airport,35.86667,-84.683334,944,http://www.rockwoodtn.org/airport.html,America/New_York,RKW,US,Rockwood,Tennessee,Roane County,AP
 RKY,,Rokeby,-13.166667,143.43333,200,,Australia/Brisbane,RKY,AU,,,,AP
 RKZ,ZURK,Peace,29.351944,89.31,12470,,Asia/Shanghai,RKZ,CN,Car,Tibet Autonomous Region,,AP
-RLA,,National,38.127777,-91.77805,1148,,America/Chicago,RLA,US,,,,AP
 RLD,,Richland,46.30361055,-119.30409421518716,393,,America/Los_Angeles,RLD,US,Richland,Washington,Benton County,AP
 RLG,ETNL,Laage Airport,53.919142750000006,12.276204371080205,114,,Europe/Berlin,RLG,DE,Laage,Mecklenburg-Vorpommern,,AP
 RLK,ZBYZ,Bayannur Tianjitai Airport,40.928311699999995,107.73447335946133,3362,,Asia/Shanghai,RLK,CN,Xamba,Inner Mongolia,,AP
@@ -8268,7 +8242,6 @@ UIP,LFRQ,Pluguffan Airport,47.974445,-4.170833,297,,Europe/Paris,UIP,FR,Pluguffa
 UIQ,NVVQ,Quine Hill,-17.0,168.16667,16,,Pacific/Efate,UIQ,VU,,,,AP
 UIR,YQDI,Quirindi,-31.4965337,150.5221114,1054,,Australia/Sydney,UIR,AU,Quirindi,New South Wales,Liverpool Plains,AP
 UIT,,Jaluit Island,5.833333,169.61667,4,,Pacific/Majuro,UIT,MH,Jabor,Jaluit Atoll,,AP
-UIZ,,Berz-Macomb,42.61667,-83.05,0,,America/Detroit,UIZ,US,Utica,Michigan,Macomb County,AP
 UJE,,Ujae Island,9.083333,165.66667,29,,Pacific/Majuro,UJE,MH,Ujae,Ujae Atoll,,AP
 UJN,RKTL,Uljin,36.7775619,129.46312595227198,191,,Asia/Seoul,UJN,KR,Cheongsong gun,Gyeongsangbuk-do,,AP
 UJU,,Uiju Airfield,40.1505605,124.49878687367472,0,,Asia/Pyongyang,UJU,KP,Uiju,P'yongan-bukto,,AP

--- a/airports.csv
+++ b/airports.csv
@@ -1971,7 +1971,6 @@ DOB,WAPD,Dobo Airport,-5.75,134.0,0,,Asia/Jayapura,DOB,ID,,,,AP
 DOC,EGZJ,Dornoch,57.868827,-4.023288,32,http://www.dornochairfield.com/,Europe/London,DOC,GB,Dornoch,Scotland,Highland,AP
 DOD,HTDO,Dodoma Airport,-6.1700681500000005,35.754430618763045,3622,,Africa/Dar_es_Salaam,DOD,TZ,Dodoma,Dodoma,,AP
 DOE,SMDJ,Djoemoe,4.016667,-55.483334,288,,America/Paramaribo,DOE,SR,,,,AP
-DOF,,Dora Bay,55.2125,-132.26666,0,,America/Sitka,DOF,US,,,,AP
 DOG,HSDN,Dongola,19.1533534,30.43057893663059,702,,Africa/Khartoum,DOG,SD,Dongola,Northern State,,AP
 DOH,OTHH,Hamad International Airport,25.267569,51.558067,78,http://dohahamadairport.com/,Asia/Qatar,DOH,QA,Doha,Baladiyat ad Dawhah,,AP
 DOI,AYDO,Doini,-10.701181250000001,150.7230841868182,32,,Pacific/Port_Moresby,DOI,PG,,,,AP
@@ -1991,7 +1990,6 @@ DPA,KDPA,DuPage Airport,41.90513465,-88.25218333266092,731,http://www.dupageairp
 DPB,SCBI,Pampa Guanaco Airport,-54.05,-68.808333,505,,America/Santiago,DPB,CL,,,,AP
 DPE,LFAB,Dieppe,49.961388,1.241111,390,,Europe/Paris,DPE,FR,Saint-Martin-en-Campagne,Haute-Normandie,Departement de la Seine-Maritime,AP
 DPG,KDPG,Michael AAF,40.233334,-112.75,4908,,America/Denver,DPG,US,Grantsville,Utah,Tooele County,AP
-DPK,,Deer Park,41.0,-73.53333,0,,America/New_York,DPK,US,Old Greenwich,Connecticut,Fairfield County,AP
 DPL,RPMG,Dipolog Airport,8.602411799999999,123.34199697345741,29,http://www.dipologcity.com/AccommodationsDipolog%20Airport.htm,Asia/Manila,DPL,PH,Dipolog,Zamboanga Peninsula,Province of Zamboanga del Norte,AP
 DPO,YDPO,Devonport Airport,-41.1717979,146.42759229572462,29,http://www.tasports.com.au/infrastructure/devonport_airport.html,Australia/Hobart,DPO,AU,,,,AP
 DPP,,Datia Airport,25.649972,78.503167,779,,Asia/Kolkata,DPP,IN,,,,AP
@@ -2058,7 +2056,6 @@ DUG,KDUG,Bisbee-Douglas International,31.46388645,-109.6048261340828,4091,http:/
 DUJ,KDUJ,Du Bois-Jefferson County,41.178333,-78.89889,1784,,America/New_York,DUJ,US,Reynoldsville,Pennsylvania,Jefferson County,AP
 DUK,FADK,Dukuduk,-28.366667,32.234165,291,,Africa/Johannesburg,DUK,ZA,Mtubatuba,KwaZulu-Natal,uMkhanyakude District Municipality,AP
 DUM,WIBD,Pinang Kampai,1.60899315,101.43332717293623,72,,Asia/Jakarta,DUM,ID,Bagan Besar,Riau,,AP
-DUN,,Dundas,76.577225,-68.77556,0,,America/Godthab,DUN,GL,,,,AP
 DUQ,CAM3,Duncan/Quam,48.783333,-123.7,26,,America/Vancouver,DUQ,CA,Duncan,British Columbia,,AP
 DUR,FALE,King Shaka International Airport,-29.6099422,31.11688170804795,246,,Africa/Johannesburg,DUR,ZA,Ballitoville,KwaZulu-Natal,iLembe District Municipality,AP
 DUS,EDDL,Dusseldorf International Airport,51.2869035,6.761736665024513,108,http://www.dus.com/dus_en/,Europe/Berlin,DUS,DE,,,,AP
@@ -2075,9 +2072,7 @@ DWA,FWDW,Dwangwa,-13.0,34.13333,2014,,Africa/Blantyre,DWA,MW,Nkhotakota,Central 
 DWB,FMNO,Soalala,-16.101381,45.3581714,111,,Indian/Antananarivo,DWB,MG,Sitampiky,Boeny,,AP
 DWC,OMDW,Dubai World Central - Al Maktoum International Airport,24.918056,55.175278,104,,Asia/Dubai,DXB,AE,,,,AP
 DWD,OEDM,Dawadmi Airport,24.4500793,44.1258191651475,3061,,Asia/Riyadh,DWD,SA,Ad Dawadimi,Ar Riyad,,AP
-DWF,,Wright AFB,39.666668,-84.183334,879,,America/New_York,DAY,US,Kettering,Ohio,Montgomery County,AP
 DWH,KDWH,David Wayne Hooks,29.75,-95.416664,78,http://www.hooksairport.com/,America/Chicago,HOU,US,,,,AP
-DWN,,Downtown Airpark,35.45,-97.53333,1210,,America/Chicago,OKC,US,,,,AP
 DWO,,Diyawanna Oya Seaplane Base,6.904439,79.9093208,42,,Asia/Colombo,DWO,LK,Battaramulla South,Western,,AP
 DWR,,Dwyer Air Base,31.0,64.0,2385,http://militarybases.com/overseas/afghanistan/camp-dwyer/,Asia/Kabul,DWR,AF,Markaz-e Hukumat-e Darweshan,Helmand,,AP
 DWS,,Walt Disney World,28.4020746,-81.5722231,65,,America/New_York,ORL,US,Celebration,Florida,Osceola County,AP
@@ -2121,7 +2116,6 @@ EBL,ORER,Erbil International Airport,36.23784135,43.9489017061083,1164,,Asia/Bag
 EBM,DTTR,El Borma,31.70399195,9.254241482361664,790,,Africa/Tunis,EBM,TN,Remada,Tataouine,,AP
 EBN,,Ebadon,9.3305597,166.8200073,29,,Pacific/Kwajalein,EBN,MH,,,,AP
 EBO,,Ebon Airport,4.5988889,168.7530556,26,,Pacific/Majuro,EBO,MH,Ebon,Ebon Atoll,,AP
-EBR,,Downtown,30.45,-91.183334,82,,America/Chicago,BTR,US,Port Allen,Louisiana,West Baton Rouge Parish,AP
 EBS,KEBS,Municipal,42.466667,-93.816666,1056,,America/Chicago,EBS,US,Webster City,Iowa,Hamilton County,AP
 EBU,LFMH,Boutheon Airport,45.54139,4.296944,1256,,Europe/Paris,EBU,FR,Veauche,Rhone-Alpes,Departement de la Loire,AP
 EBW,FKKW,Ebolowa,2.916667,11.166667,2014,,Africa/Douala,EBW,CM,Ebolowa,South Province,,AP
@@ -2140,7 +2134,6 @@ EDC,KEDC,Austin Executive Airport,30.3974931,-97.5663935,620,,America/Chicago,ED
 EDD,YERL,Erldunda,-25.25,133.2,1354,,Australia/Darwin,EDD,AU,,,,AP
 EDE,KEDE,Municipal,36.066666,-76.65,29,,America/New_York,EDE,US,Edenton,North Carolina,Chowan County,AP
 EDF,PAED,Elmendorf AFB,61.25323915,-149.80818022420294,200,,America/Anchorage,ANC,US,,,,AP
-EDG,,Weide AAF,39.465668,-76.360916,246,,America/New_York,EDG,US,Joppatowne,Maryland,Harford County,AP
 EDI,EGPH,Edinburgh Airport,55.950128899999996,-3.3595079855289756,72,http://www.edinburghairport.com/,Europe/London,EDI,GB,Ratho,Scotland,Edinburgh,AP
 EDK,KEQA,El Dorado,37.816666,-96.86667,1338,http://www.eldoks.com/Airport%20Cover.html,America/Chicago,EDK,US,El Dorado,Kansas,Butler County,AP
 EDL,HKEL,Eldoret Airport,0.4043631,35.23328885990355,6837,http://www.kenyaairports.co.ke/kaa/airports/eldoret/,Africa/Nairobi,EDL,KE,Eldoret,Uasin Gishu,,AP
@@ -2155,12 +2148,10 @@ EED,KEED,Needles,34.85,-114.61667,482,http://cms.sbcounty.gov/airports/Airports/
 EEK,PAEE,Eek Airport,60.21367395,-162.04395780488488,32,,America/Nome,EEK,US,,,,AP
 EEN,KEEN,Dillant-Hopkins,42.8946227,-72.26985656446831,449,,America/New_York,EEN,US,Swanzey,New Hampshire,Cheshire County,AP
 EES,,Berenice International Airport,23.980303,35.45003685693535,55,,Africa/Cairo,IUP,EG,Berenice City,,,AP
-EFB,,Eight Fathom Bight,58.0,-135.73334,0,,America/Juneau,EFB,US,,,,AP
 EFD,KEFD,Ellington Field,29.6,-95.15,32,,America/Chicago,HOU,US,Webster,Texas,Harris County,AP
 EFG,AYEF,Efogi,-9.1537629,147.65981923737388,3887,,Pacific/Port_Moresby,EFG,PG,,,,AP
 EFK,KEFK,Newport,44.889442,-72.23,928,,America/New_York,EFK,US,,,,AP
 EFL,LGKF,Kefallinia Airport,38.120146399999996,20.50046516809963,65,,Europe/Athens,EFL,GR,Argostolion,Ionian Islands,Nomos Kefallinias,AP
-EFO,,East Fork Airport,64.69277777,-164.276388,147,,America/Nome,EFO,US,,,,AP
 EFW,KEFW,Municipal,42.016666,-94.38333,1049,http://cityofjeffersoniowa.org/depts-airport.php,America/Chicago,EFW,US,Jefferson,Iowa,Greene County,AP
 EGA,AYEN,Engati,-6.917968050000001,146.10562831870763,3677,,Pacific/Port_Moresby,EGA,PG,,,,AP
 EGC,LFBE,Roumanieres Airport,44.85,0.483333,91,,Europe/Paris,EGC,FR,Bergerac,Aquitaine,Departement de la Dordogne,AP
@@ -2176,7 +2167,6 @@ EGV,KEGV,Eagle River,45.92917,-89.26583,1660,http://www.erairport.com/,America/C
 EGX,PAII,Egegik Airport,58.1876085,-157.3757513,36,,America/Anchorage,EGX,US,,,,AP
 EHL,SAVB,El Bolson,-42.0,-71.75,4740,,America/Argentina/Salta,EHL,AR,Lago Puelo,Chubut,,AP
 EHM,PAEH,Cape Newenham,58.6463889,-162.0625,288,,America/Nome,EHM,US,,,,AP
-EHT,,Rentschler,41.766666,-72.65,55,,America/New_York,EHT,US,,,,AP
 EHU,ZHEC,Ezhou Huahu Airport,30.346,115.0474,65,,Asia/Shanghai,EHU,CN,Ezhou,,,AP
 EIA,,Popondetta,-8.116667,147.63333,643,,Pacific/Port_Moresby,EIA,PG,,,,AP
 EIB,EDGE,Eisenach,50.983334,10.483333,974,http://www.flugplatz-eisenach.de/,Europe/Berlin,EIB,DE,Haina,Thuringia,,AP
@@ -2228,7 +2218,6 @@ ELX,,El Tigre,8.883333,-64.26667,1017,,America/Caracas,ELX,VE,El Tigre,Anzoategu
 ELY,KELY,Yelland,39.301945,-114.84194,6236,,America/Los_Angeles,ELY,US,Ely,Nevada,White Pine County,AP
 ELZ,KELZ,Municipal,42.11667,-77.95,1509,,America/New_York,ELZ,US,Wellsville,New York,Allegany County,AP
 EMA,EGNX,East Midlands Airport,52.832787,-1.3409974,259,http://www.eastmidlandsairport.com/,Europe/London,NQT,GB,Castle Donington,England,Leicestershire,AP
-EMB,,Embarkadero,37.62528,-122.375,42,,America/Los_Angeles,SFO,US,,,,AP
 EMD,YEML,Emerald Airport,-23.5694249,148.17632214869155,616,http://www.emerald.qld.gov.au/Council/Departments/Engineering_Operations/Engineering_Operations.htm,Australia/Brisbane,EMD,AU,Emerald,Queensland,Central Highlands,AP
 EME,EDWE,Emden,53.3901805,7.2276361,29,,Europe/Berlin,EME,DE,Emden,Lower Saxony,,AP
 EMG,FAEM,Empangeni,-28.7195011,31.8927469,209,,Africa/Johannesburg,EMG,ZA,Empangeni,KwaZulu-Natal,uThungulu District Municipality,AP
@@ -2257,7 +2246,6 @@ ENK,EGAB,Enniskillen St. Angelo,54.35,-7.633333,157,,Europe/London,ENK,GB,Ennisk
 ENL,KENL,Municipal,38.516666,-89.13333,511,,America/Chicago,ENL,US,Centralia,Illinois,Marion County,AP
 ENN,PANN,Municipal,64.566666,-149.11667,351,,America/Anchorage,ENN,US,,,,AP
 ENO,SGEN,Teniente Prim Alarcon,-27.25,-55.833332,449,,America/Asuncion,ENO,PY,Capitan Miranda,Itapua,,AP
-ENQ,,Coronel E Soto Cano AB,14.369167,-87.617226,2030,,America/Tegucigalpa,ENQ,HN,Yarumela,La Paz,,AP
 ENS,EHTW,Twente,52.2781025,6.882574,88,https://www.twente-airport.nl/,Europe/Amsterdam,ENS,NL,,,,AP
 ENT,PKMA,Enewetak Island,11.5,162.25,0,,Pacific/Majuro,ENT,MH,,,,AP
 ENU,DNEN,Enugu Airport,6.471979599999999,7.55671795401768,469,http://www.faannigeria.org/nigeria-airport.php?airport=11,Africa/Lagos,ENU,NG,Enugu,Enugu,,AP
@@ -2273,11 +2261,9 @@ EOZ,SVEZ,Elorza,7.166667,-69.53333,278,,America/Caracas,EOZ,VE,Elorza,Apure,Muni
 EPA,SADP,El Palomar,-34.6150101,-58.60976216632794,95,,America/Argentina/Buenos_Aires,EPA,AR,Hurlingham,Buenos Aires,,AP
 EPG,NE69,Browns,40.86667,-96.13333,1204,,America/Chicago,EPG,US,Weeping Water,Nebraska,Cass County,AP
 EPH,KEPH,Ephrata,47.3063398,-119.51545,1230,http://www.portofephrata.com/index.htmlA,America/Los_Angeles,EPH,US,Ephrata,Washington,Grant County,AP
-EPI,,Epi,-16.716667,168.25,521,,Pacific/Efate,EPI,VU,,,,AP
 EPL,LFSG,Mirecourt,48.3218532,6.068698232464362,1026,http://www.epinal-mirecourt.aeroport.fr,Europe/Paris,EPL,FR,Mirecourt,Lorraine,Departement des Vosges,AP
 EPN,,Epena,1.366667,17.533333,1020,,Africa/Brazzaville,EPN,CG,,,,AP
 EPR,YESP,Esperance Airport,-33.684036500000005,121.82450125089962,406,,Australia/Perth,EPR,AU,Nulsen,Western Australia,Esperance Shire,AP
-EPS,MDPO,Arroyo Barril International,19.25,-69.5,974,,America/Santo_Domingo,EPS,DO,Las Terrenas,Samana,,AP
 EPT,AYEL,Eliptamin,-5.04175185,141.67824597773895,4753,,Pacific/Port_Moresby,EPT,PG,,,,AP
 EPU,EEPU,Parnu,58.41979255,24.470041647645797,45,,Europe/Tallinn,EPU,EE,Sauga,Paernumaa,Sauga vald,AP
 EQS,SAVE,Esquel Airport,-42.90427405,-71.13444374688999,2565,,America/Argentina/Catamarca,EQS,AR,Esquel,Chubut,Departamento de Futaleufu,AP
@@ -2351,7 +2337,6 @@ EVV,KEVV,Evansville Regional Airport,38.04188775,-87.5296839642167,377,,America/
 EVW,KEVW,Evanston,41.266666,-110.96667,6765,,America/Denver,EVW,US,Evanston,Wyoming,Uinta County,AP
 EVX,LFOE,Evreux,49.016666,1.15,393,,Europe/Paris,EVX,FR,Evreux,Haute-Normandie,Departement de l'Eure,AP
 EWB,KEWB,New Bedford Airport,41.6765725,-70.95929008264703,62,,America/New_York,EWB,US,New Bedford,Massachusetts,Bristol County,AP
-EWD,,Wildman Lake,56.45639,-159.76222,36,,America/Anchorage,EWD,US,,,,AP
 EWE,,Ewer,-5.4949737,138.080500210884,36,,Asia/Jayapura,EWE,ID,,,,AP
 EWI,WABT,Enarotali,-3.966667,136.33333,6679,,Asia/Jayapura,EWI,ID,Enarotali,Papua,,AP
 EWK,KEWK,City-County,38.033333,-97.36667,1456,http://www.newtonkansas.com/index.aspx?page=40,America/Chicago,EWK,US,Newton,Kansas,Harvey County,AP
@@ -2381,7 +2366,6 @@ FAH,OAFR,Farah,32.3655368,62.16252289843064,2194,,Asia/Kabul,FAH,AF,Farah,Farah,
 FAI,PAFA,Fairbanks International Airport,64.81761,-147.86784231862563,442,,America/Anchorage,FAI,US,,,,AP
 FAJ,TJFA,Diego Jimenez Torres,18.338888,-65.50222,0,,America/Puerto_Rico,FAJ,PR,Luis M. Cintron,Fajardo,,AP
 FAK,2Z6,False Island,57.5324682,-135.2132601,0,,America/Sitka,FAK,US,,,,AP
-FAL,,Falcon State,26.583332,-99.13333,328,,America/Chicago,FAL,US,Nueva Ciudad Guerrero,Tamaulipas,,AP
 FAM,KFAM,Regional,37.780834,-90.42167,925,http://farmington-mo.gov/airport.cfm,America/Chicago,FAM,US,Farmington,Missouri,Saint Francois County,AP
 FAO,LPFR,Faro Airport,37.017459599999995,-7.973911065722614,29,http://www.ana.pt/en-US/Aeroportos/algarve/Faro/Pages/HomeFaro.aspx,Europe/Lisbon,FAO,PT,,,,AP
 FAQ,AYFR,Freida River,-4.616667,141.95833,226,,Pacific/Port_Moresby,FAQ,PG,,,,AP
@@ -2409,7 +2393,6 @@ FCM,KFCM,Flying Cloud Airport,44.983334,-93.26667,902,http://www.metroairports.o
 FCN,ETMN,Cuxhaven/Nordholz,53.7721471,8.662276556603832,45,,Europe/Berlin,FCN,DE,Midlum,Lower Saxony,,AP
 FCO,LIRF,Leonardo da Vinci-Fiumicino Airport,41.8144309,12.226901204880779,32,http://www.adr.it/portal/portal/adr/Fiumicino/Leonardo_da_vinci/Header_Window?action=2,Europe/Rome,ROM,IT,Fiumicino-Isola Sacra,Latium,Citta metropolitana di Roma Capitale,AP
 FCS,KFCS,Butts AAF,38.833332,-104.816666,6030,,America/Denver,COS,US,Colorado Springs,Colorado,El Paso County,AP
-FCT,,Firing Center AAF,46.6,-120.51667,1059,,America/Los_Angeles,YKM,US,,,,AP
 FCY,KFCY,Municipal,34.95,-90.76667,246,http://www.fly.arkansas.gov/Airports/ForrestCity/FORREST_CITY-2.pdf,America/Chicago,FCY,US,Forrest City,Arkansas,Saint Francis County,AP
 FDE,ENBL,Bringeland Airport,61.39153845,5.760503549358087,1056,https://avinor.no/en/airport/forde-airport/,Europe/Oslo,FDE,NO,Sande,Sogn og Fjordane,Gaular,AP
 FDF,TFFF,Martinique Aime Cesaire International Airport,14.5906832,-61.00559445393026,26,http://www.martinique.aeroport.fr/,America/Martinique,FDF,MQ,Le Lamentin,Martinique,Martinique,AP
@@ -2427,9 +2410,7 @@ FEK,DIFK,Ferkessedougou,9.6000004,-5.1999998,1020,,Africa/Abidjan,FEK,CI,Ferkess
 FEL,ETSF,Fuerstenfeldbruck,48.2,11.266667,1709,,Europe/Berlin,FEL,DE,Maisach,Bavaria,Upper Bavaria,AP
 FEN,SBFN,Fernando De Noronha Airport,-3.8546858,-32.4227495764598,150,,America/Noronha,FEN,BR,Fernando de Noronha (Distrito Estadual),Pernambuco,Fernando De Noronha,AP
 FEP,KFEP,Albertus,42.24424695,-89.58328993042613,830,http://www.ci.freeport.il.us/business/albertus.htm,America/Chicago,FEP,US,Freeport,Illinois,Stephenson County,AP
-FES,,San Fernando,36.466667,-6.183333,22,,Europe/Madrid,FES,ES,San Fernando,Andalusia,Provincia de Cadiz,AP
 FET,KFET,Municipal,41.433334,-96.5,1217,http://www.fremontne.gov/index.aspx?nid=398,America/Chicago,FET,US,Fremont,Nebraska,Dodge County,AP
-FEW,,Warren AFB,41.14232855,-104.87201176270457,6148,,America/Denver,CYS,US,Cheyenne,Wyoming,Laramie County,AP
 FEZ,GMFF,Fes-Saiss Airport,33.929115949999996,-4.979095413023916,1883,,Africa/Casablanca,FEZ,MA,Oulad Tayeb,Fes-Boulemane,Fes,AP
 FFA,KFFA,First Flight,36.0176628,-75.67153016364745,26,,America/New_York,FFA,US,Kill Devil Hills,North Carolina,Dare County,AP
 FFD,EGVA,Fairford RAF Station,51.733334,-1.783333,377,,Europe/London,FFD,GB,Fairford,England,Gloucestershire,AP
@@ -2440,12 +2421,9 @@ FFT,KFFT,Capital City,38.18222,-84.905,774,http://cca.ky.gov/Pages/default.aspx,
 FFU,SCFT,Futaleufu,-43.1889648,-71.85031648848118,1125,,America/Santiago,FFU,CL,Futaleufu,Los Lagos,Provincia de Palena,AP
 FGD,GQPF,Fderik,22.6733397,-12.7288263,961,,Africa/Nouakchott,FGD,MR,,,,AP
 FGI,NSFI,Fagali I Airport,-13.8495609,-171.73900401758772,111,,Pacific/Apia,APW,WS,Apia,Tuamasaga,,AP
-FGL,,Fox Glacier,-43.466667,170.01666,524,,Pacific/Auckland,FGL,NZ,,,,AP
-FGR,,Fuengirola,36.533333,-4.633333,32,,Europe/Madrid,FGR,ES,Fuengirola,Andalusia,Provincia de Malaga,AP
 FGU,NTGB,Fangatau,-16.05,-141.83333,0,,Pacific/Tahiti,FGU,PF,,,,AP
 FHU,KFHU,Municipal,31.588888,-110.343056,4625,,America/Phoenix,FHU,US,Huachuca City,Arizona,Cochise County,AP
 FHZ,NTKH,Fakahina,-15.9916371,-140.1647412,32,,Pacific/Tahiti,FHZ,PF,,,,AP
-FIC,,Fire Cove,55.77778,-131.5375,0,,America/Juneau,FIC,US,,,,AP
 FID,0B8,Elizabeth Field,41.0,-72.0,0,https://www.dot.ny.gov/divisions/operating/opdm/aviation/repository/air_dir2/Elizabeth-revised.pdf,America/New_York,FID,US,,,,AP
 FIE,EGEF,Fair Isle,59.5347796,-1.6284978260484486,259,http://www.fairisle.org.uk/egef/index.htm,Europe/London,SDZ,GB,,,,AP
 FIG,GUFA,Fria,10.3515213,-13.5691599,547,,Africa/Conakry,FIG,GN,Fria,Boke,Fria,AP
@@ -2453,7 +2431,6 @@ FIH,FZAA,N'djili Airport,-4.389588,15.447338,1010,,Africa/Kinshasa,FIH,CD,Masina
 FIK,YFNE,Finke,-25.566668,134.58333,928,,Australia/Darwin,FIK,AU,,,,AP
 FIL,KFOM,Municipal,38.958332,-112.3625,4967,,America/Denver,FIL,US,Fillmore,Utah,Millard County,AP
 FIN,AYFI,Finschhafen,-6.6207783,147.8537867495256,65,,Pacific/Port_Moresby,FIN,PG,,,,AP
-FIV,,Five Finger,57.266666,-133.63333,0,,America/Juneau,FIV,US,,,,AP
 FIZ,YFTZ,Fitzroy Crossing,-18.1818248,125.55918151085643,400,,Australia/Perth,FIZ,AU,,,,AP
 FJR,OMFJ,Al-Fujairah International,25.1102772,56.32334682899914,95,,Asia/Dubai,FJR,AE,Al Fujayrah,Al Fujayrah,,AP
 FKB,EDSB,Baden-Airpark,48.7787136,8.081971309890005,406,http://www.baden-airpark.de/startseite.html,Europe/Berlin,FKB,DE,Hugelsheim,Baden-Wuerttemberg,Karlsruhe Region,AP
@@ -2465,13 +2442,11 @@ FKQ,WASF,Fak Fak Airport,-2.916667,132.3,511,,Asia/Jayapura,FKQ,ID,Fakfak,Papua,
 FKS,RJSF,Fukushima Airport,37.2272,140.4306,1194,http://www.fks-ab.co.jp/,Asia/Tokyo,FKS,JP,Sukagawa,Fukushima,,AP
 FLA,SKFL,Capitolio Airport,1.588889,-75.55889,761,,America/Bogota,FLA,CO,Florencia,Caqueta,,AP
 FLB,SNQG,Cangapara,-6.8,-43.033333,442,,America/Fortaleza,FLB,BR,Floriano,Piaui,Floriano,AP
-FLC,,Falls Creek,-36.833332,143.28334,1151,,Australia/Melbourne,FLC,AU,Maryborough,Victoria,Central Goldfields,AP
 FLD,KFLD,Fond Du Lac,43.771667,-88.48444,790,http://www.fdlco.wi.gov/departments/departments-a-e/airport,America/Chicago,FLD,US,North Fond du Lac,Wisconsin,Fond du Lac County,AP
 FLF,EDXF,Schaferhaus,54.77174585,9.37996456704682,111,,Europe/Berlin,FLF,DE,Harrislee,Schleswig-Holstein,,AP
 FLG,KFLG,Flagstaff Pulliam Airport,35.140398250000004,-111.67020441781051,7004,,America/Phoenix,GCN,US,Kachina Village,Arizona,Coconino County,AP
 FLH,EGZR,Flotta,58.5,-3.0,0,,Europe/London,FLH,GB,,,,AP
 FLI,BIHT,Flateyri,65.98333,-23.7,1906,,Atlantic/Reykjavik,FLI,IS,,,,AP
-FLJ,,Falls Bay,60.0325,-148.00833,393,,America/Anchorage,FLJ,US,,,,AP
 FLL,KFLL,Fort Lauderdale-Hollywood International Airport,26.072017000000002,-80.15099673135214,45,http://www.broward.org/airport,America/New_York,FLL,US,,,,AP
 FLM,SGFI,Filadelfia,-22.357841,-60.053753667301976,495,,America/Asuncion,FLM,PY,Filadelfia,Boqueron,,AP
 FLN,SBFL,Hercilio Luz International Airport,-27.670113450000002,-48.54468648648172,19,http://www.infraero.gov.br/usa/aero_prev_home.php?ai=228,America/Sao_Paulo,FLN,BR,Carianos,Santa Catarina,Florianopolis,AP

--- a/airports.csv
+++ b/airports.csv
@@ -21,7 +21,6 @@ AAS,,Apalapsili,-3.880849,139.3107060627146,3005,,Asia/Jayapura,AAS,ID,,,,AP
 AAT,ZWAT,Altay Airport,47.74833705,88.08948249042332,2408,,Asia/Urumqi,AAT,CN,Awiytan,Xinjiang Uygur Zizhiqu,,AP
 AAU,NSAU,Asau,-13.458333,-172.6,0,,Pacific/Apia,AAU,WS,Asau,Vaisigano,,AP
 AAV,RPMA,Allah Valley,6.36768745,124.75266160348093,629,,Asia/Manila,AAV,PH,Surallah,South Cotabato,,AP
-AAW,OPAB,Abbottabad,34.2,73.25,4061,,Asia/Karachi,AAW,PK,Abbottabad,Khyber Pakhtunkhwa,,AP
 AAX,SBAX,Araxa Airport,-19.563132000000003,-46.96040575380038,3267,,America/Sao_Paulo,AAX,BR,Araxa,Minas Gerais,Araxa,AP
 AAY,OYGD,Al Ghaydah,16.1879658,52.17271501755243,114,,Asia/Aden,AAY,YE,Al Ghayzah,Al Mahrah,Al Ghaydah,AP
 AAZ,MGQZ,Quetzaltenango,14.8611558,-91.5067713438188,7795,,America/Guatemala,AAZ,GT,Olintepeque,Quetzaltenango,,AP
@@ -102,11 +101,9 @@ ADY,FAAL,Alldays,-22.67767555,29.053395555022227,2683,,Africa/Johannesburg,ADY,Z
 ADZ,SKSP,Gustavo Rojas Pinilla Airport,12.586047,-81.70221,39,,America/Bogota,ADZ,CO,San Andres,"Archipielago de San Andres, Providencia y Santa Catalina",,AP
 AEA,NGTB,Abemama Atoll,0.490833,173.8289948,36,,Pacific/Tarawa,AEA,KI,,,,AP
 AEB,ZGBS,Youjiang,23.72020895,106.9609714096124,452,,Asia/Shanghai,AEB,CN,Tianzhou,Guangxi Zhuangzu Zizhiqu,,AP
-AED,,Aleneva,58.033333,-152.9,1099,,America/Anchorage,AED,US,,,,AP
 AEE,,Adareil Airport,10.052439199999998,32.962007213556745,1246,,Africa/Juba,AEE,SS,,,,AP
 AEG,WIME,Aek Godang,1.3999603999999999,99.42983272544998,925,,Asia/Jakarta,AEG,ID,Padangsidempuan,North Sumatra,,AP
 AEH,FTTC,Abéché,13.8465726,20.849645040165157,1778,,Africa/Ndjamena,AEH,TD,Abeche,Ouaddai,,AP
-AEI,,Algeciras,36.1289,-5.441301,42,,Europe/Madrid,AEI,ES,Algeciras,Andalusia,Provincia de Cadiz,AP
 AEK,AYAX,Aseki,-7.366667,146.28334,3694,,Pacific/Port_Moresby,AEK,PG,,,,AP
 AEL,KAEL,Albert Lea,43.6800949,-93.36737639309429,1250,,America/Chicago,AEL,US,Albert Lea,Minnesota,Freeborn County,AP
 AEM,UHTG,Amgu,45.8414555,137.67364088576272,22,,Asia/Vladivostok,AEM,RU,,,,AP
@@ -145,7 +142,6 @@ AGI,SMWA,Wageningen,5.833333,-56.833332,19,,America/Paramaribo,AGI,SR,Wageningen
 AGJ,RORA,Aguni,26.59300295,127.23985985060742,32,,Asia/Tokyo,AGJ,JP,,,,AP
 AGK,,Kagua,-6.403333,143.84666,5554,,Pacific/Port_Moresby,AGK,PG,,,,AP
 AGL,AYWG,Wanigela,-9.33738355,149.15610272068812,29,,Pacific/Port_Moresby,AGL,PG,,,,AP
-AGM,,Tasiilaq,65.6,-37.683334,534,,America/Godthab,AGM,GL,,,,AP
 AGN,PAGN,Angoon,57.503887,-134.58333,0,,America/Juneau,AGN,US,,,,AP
 AGO,KAGO,Municipal,33.266666,-93.23333,314,,America/Chicago,AGO,US,Magnolia,Arkansas,Columbia County,AP
 AGP,LEMG,Malaga Airport,36.67876135,-4.499980126161259,52,,Europe/Madrid,AGP,ES,,,,AP
@@ -277,7 +273,6 @@ AMN,KAMN,Gratiot Community,43.38333,-84.65,751,http://www.ci.alma.mi.us/1/307/ai
 AMO,FTTU,Mao,14.116667,15.316667,1049,,Africa/Ndjamena,AMO,TD,Mao,Kanem,,AP
 AMP,FMSY,Ampanihy,-24.6996994,44.7341995,725,,Indian/Antananarivo,AMP,MG,Ampanihy,Atsimo-Andrefana,,AP
 AMQ,WAPP,Pattimura Airport,-3.7111152499999998,128.0878877356375,49,,Asia/Jayapura,AMQ,ID,Amahusu,Maluku,,AP
-AMR,,Arno,7.033333,171.23334,0,,Pacific/Majuro,AMR,MH,,,,AP
 AMS,EHAM,Amsterdam Airport Schiphol,52.32697895,4.741505200022974,36,http://www.schiphol.nl/,Europe/Amsterdam,AMS,NL,Aalsmeer,North Holland,Gemeente Aalsmeer,AP
 AMT,YAMT,Amata,-26.766666,132.03334,1748,,Australia/Adelaide,AMT,AU,,,,AP
 AMU,AYAM,Amanab,-3.516667,141.15,1112,,Pacific/Port_Moresby,AMU,PG,,,,AP
@@ -293,7 +288,6 @@ AND,KAND,Anderson,34.49361,-82.71,728,,America/New_York,AND,US,Centerville,South
 ANE,LFJR,Angers-Marce Airport,47.466667,-0.55,144,,Europe/Paris,ANE,FR,,,,AP
 ANF,SCFA,Cerro Moreno International Airport,-23.452375699999997,-70.43973434352753,347,,America/Santiago,ANF,CL,Antofagasta,Antofagasta,Provincia de Antofagasta,AP
 ANG,LFBU,Brie-Champniers,45.733334,0.216667,396,,Europe/Paris,ANG,FR,Champniers,Poitou-Charentes,Departement de la Charente,AP
-ANH,,Anuha Island Resort,-8.983333,160.5,0,,Pacific/Guadalcanal,ANH,SB,,,,AP
 ANI,PANI,Aniak Airport,61.5813889,-159.5427778,49,,America/Anchorage,ANI,US,,,,AP
 ANJ,FCBZ,Zanaga,-2.8474064,13.8214267,1863,,Africa/Brazzaville,ANJ,CG,,,,AP
 ANK,LTAD,Etimesgut,39.951794199999995,32.68941441008361,2627,,Europe/Istanbul,ANK,TR,Batikent,Ankara,,AP
@@ -305,7 +299,6 @@ ANP,KANP,Lee,38.983334,-76.5,29,,America/New_York,ANP,US,Annapolis,Maryland,Anne
 ANQ,KANQ,Tri-State Steuben County,41.63333,-85.0,1053,,America/Indiana/Indianapolis,ANQ,US,Angola,Indiana,Steuben County,AP
 ANR,EBAW,Antwerp International Airport,51.1881429,4.463473861141249,29,http://www.antwerp-airport.be/,Europe/Brussels,ANR,BE,Mortsel,Flanders,Provincie Antwerpen,AP
 ANS,SPHY,Andahuaylas,-13.709079,-73.35160446460571,11581,,America/Lima,ANS,PE,San Jeronimo,Apurimac,Provincia de Andahuaylas,AP
-ANT,,St Anton,47.15,10.283333,5672,,Europe/Vienna,ANT,AT,Sankt Anton am Arlberg,Tyrol,Politischer Bezirk Landeck,AP
 ANU,TAPA,V.C. Bird International Airport,17.13578595,-61.79381928408262,42,,America/Antigua,ANU,AG,Parham,Saint Peter,,AP
 ANV,PANV,Anvik Airport,62.6451092,-160.1932999,265,,America/Anchorage,ANV,US,,,,AP
 ANW,KANW,Ainsworth,42.55,-99.86667,2513,,America/Chicago,ANW,US,Ainsworth,Nebraska,Brown County,AP
@@ -335,7 +328,6 @@ APA,KAPA,Centennial Airport,39.733334,-104.98333,5285,,America/Denver,DEN,US,,,,
 APB,SLAP,Apolo,-14.716667,-68.51667,5282,,America/La_Paz,APB,BO,Mapiri,La Paz,,AP
 APC,KAPC,Napa County,38.216488,-122.27657132954653,32,http://www.napacountyairport.org/,America/Los_Angeles,APC,US,American Canyon,California,Napa County,AP
 APD,,Arung Palakka Airport,-4.46021,120.30683,79,,Asia/Jakarta,APD,ID,,,,AP
-APE,SPAO,San Juan Aposento,-11.933333,-69.083336,866,,America/Lima,APE,PE,,,,AP
 APF,KAPF,Naples Municipal Airport,26.1523225,-81.773941382464,29,,America/New_York,APF,US,Naples,Florida,Collier County,AP
 APG,KAPG,Phillips AAF,39.5,-76.166664,72,,America/New_York,APG,US,Aberdeen,Maryland,Harford County,AP
 APH,KAPH,Camp A P Hill,38.05,-77.35,173,,America/New_York,APH,US,Bowling Green,Virginia,Caroline County,AP
@@ -444,7 +436,6 @@ ATX,,Atbasar,51.8517097,68.3655586,997,,Asia/Almaty,ATX,KZ,Atbasar,Aqmola,,AP
 ATY,KATY,Watertown Airport,44.912617499999996,-97.14845996679145,1722,,America/Chicago,ATY,US,Watertown,South Dakota,Codington County,AP
 ATZ,HEAT,Assiut Airport,27.033333,31.0,751,,Africa/Cairo,ATZ,EG,Asyut,Asyut,,AP
 AUA,TNCA,Reina Beatrix International Airport,12.502222,-70.013885,36,,America/Aruba,AUA,AW,Oranjestad,,,AP
-AUB,,Itauba Airport,-11.878603,-55.581735,1223,,America/Cuiaba,AUB,BR,Itauba,Mato Grosso,,AP
 AUC,SKUC,Arauca Airport,7.06803755,-70.73450090889622,390,,America/Bogota,AUC,CO,Arauca,Arauca,,AP
 AUD,YAGD,Augustus Downs,-18.5149994,139.878006,98,,Australia/Brisbane,AUD,AU,,,,AP
 AUE,,Abu Rudeis,28.90059595,33.20053351373349,29,,Africa/Cairo,AUE,EG,,,,AP
@@ -516,7 +507,6 @@ AXX,KAXX,Angel Fire,36.4202498,-105.2910646,8362,,America/Denver,AXX,US,Angel Fi
 AYA,,Ayapel,8.3,-75.15,141,,America/Bogota,AYA,CO,Ayapel,Cordoba,,AP
 AYC,,Ayacucho,8.6021333,-73.6131384,393,,America/Bogota,AYC,CO,Pelaya,Cesar,,AP
 AYD,,Alroy Downs,-19.3,135.95,688,,Australia/Darwin,AYD,AU,,,,AP
-AYE,,AAF Heliport,42.55,-71.6,269,,America/New_York,AYE,US,Ayer,Massachusetts,Middlesex County,AP
 AYG,SKYA,Yaguara,1.533333,-73.933334,770,,America/Bogota,AYG,CO,,,,AP
 AYI,,Yari,-0.333333,-72.333336,485,,America/Bogota,AYI,CO,,,,AP
 AYJ,VEAY,Maharishi Valmiki International Airport,26.748034,82.150781,335,,Asia/Kolkata,AYJ,IN,Faizabad,Uttar Pradesh,,AP
@@ -534,7 +524,6 @@ AYU,AYAY,Aiyura,-6.3366412,145.90298982972382,5328,,Pacific/Port_Moresby,AYU,PG,
 AYW,WASA,Ayawasi,-1.2,132.5,1840,,Asia/Jayapura,AYW,ID,Aifat,West Papua,,AP
 AYX,SPAY,Gerardo Pérez Pinedo,-10.72845785,-73.76907295837613,767,,America/Lima,AYX,PE,Puerto Ocopa,Junin,Provincia de Satipo,AP
 AYY,,Arugam Bay SPB,6.86,81.82388889,9,,Asia/Colombo,AYY,LK,,,,AP
-AYZ,,Zahns,40.666668,-73.416664,26,,America/New_York,AYZ,US,Amityville,New York,Suffolk County,AP
 AZA,KIWA,Phoenix-Mesa Gateway Airport,33.30591455,-111.6526441150196,1309,http://www.flywga.org/,America/Phoenix,PHX,US,Queen Creek,Arizona,Maricopa County,AP
 AZB,,Amazon Bay,-10.15,148.81667,42,,Pacific/Port_Moresby,AZB,PG,,,,AP
 AZD,OIYY,Yazd Airport,31.903603,54.283264,4055,,Asia/Tehran,AZD,IR,Yazd,Yazd,,AP
@@ -563,13 +552,11 @@ BAJ,,Bali,-4.833333,149.13333,0,,Pacific/Port_Moresby,BAJ,PG,,,,AP
 BAL,LTCJ,Batman Airport,37.916668,41.083332,1765,,Europe/Istanbul,BAL,TR,Yenikoy,Batman,,AP
 BAM,KBAM,Lander County,40.63333,-116.933334,4494,http://www.battlemountainairport.com/default.htm,America/Los_Angeles,BAM,US,Battle Mountain,Nevada,Lander County,AP
 BAN,FZVR,Basongo,-4.3151816,20.4142387,1302,,Africa/Lubumbashi,BAN,CD,,,,AP
-BAO,,Udorn,17.385,102.79278,580,,Asia/Bangkok,BAO,TH,,,,AP
 BAP,,Baibara,-10.333333,149.75,104,,Pacific/Port_Moresby,BAP,PG,,,,AP
 BAQ,SKBQ,E Cortissoz Airport,10.886398,-74.77618,75,,America/Bogota,BAQ,CO,Malambo,Atlantico,,AP
 BAR,ZJQH,Baker AAF,55.333332,-133.6,954,,America/Sitka,BAR,US,,,,AP
 BAS,AGGE,Balalae,-6.9911804,155.8855471,36,,Pacific/Guadalcanal,BAS,SB,,,,AP
 BAT,SNBA,Airport Chafei Amsei,-20.55,-48.55,1732,,America/Sao_Paulo,BAT,BR,Barretos,Sao Paulo,Barretos,AP
-BAU,,Bauru Airport,-22.3450535,-49.05328145802982,2047,,America/Sao_Paulo,BRI,BR,Bauru,Sao Paulo,,AP
 BAV,ZBOW,Baotou Airport,40.56068065,109.99998138888844,3300,,Asia/Chongqing,BAV,CN,Shulinzhao,Inner Mongolia,,AP
 BAW,,Biawonque,-0.666667,146.35,0,,Africa/Libreville,BAW,GA,,,,AP
 BAX,UNBB,Barnaul Gherman Titov International Airport,53.3635611,83.5504536213013,839,http://airaltay.ru/,Asia/Omsk,BAX,RU,Gon'ba,Altai Krai,,AP
@@ -579,7 +566,6 @@ BBA,SCBA,Teniente Vidal Airport,-45.916668,-71.695,1696,,America/Santiago,BBA,CL
 BBB,KBBB,Benson Municipal Airport,45.331944,-95.650556,1026,,America/Chicago,BBB,US,Benson,Minnesota,Swift County,AP
 BBC,KBYY,Bay City,28.983334,-95.96667,72,http://www.flybaycity.com/,America/Chicago,BBC,US,Bay City,Texas,Matagorda County,AP
 BBD,KBBD,Curtis Field,31.133333,-99.333336,1686,,America/Chicago,BBD,US,Brady,Texas,McCulloch County,AP
-BBF,,Burlington,42.5,-71.183334,154,,America/New_York,BBF,US,Burlington,Massachusetts,Middlesex County,AP
 BBG,NGTU,Butaritari,3.166667,172.75,0,,Pacific/Tarawa,BBG,KI,,,,AP
 BBH,EDBH,Barth,54.33965175,12.712626338183224,26,,Europe/Berlin,BBH,DE,,,,AP
 BBI,VEBS,Biju Patnaik International Airport,20.25229545,85.81348472447162,121,http://aai.aero/allAirports/bhubaneshwar_generalinfo.jsp,Asia/Kolkata,BBI,IN,Bhubaneshwar,Odisha,Khordha,AP
@@ -679,7 +665,6 @@ BEX,EGUB,Benson RAF Station,51.63333,-1.083333,216,,Europe/London,BEX,GB,Benson,
 BEY,OLBA,Beirut-Rafic Hariri International Airport,33.8180749,35.490805228124415,42,http://www.beirutairport.gov.lb/,Asia/Beirut,BEY,LB,Baabda,Mont-Liban,,AP
 BEZ,NGBR,Beru,-1.35472,176.0070038,26,,Pacific/Tarawa,BEZ,KI,,,,AP
 BFA,SGBN,Bahia Negra,-20.2311349,-58.17057022420163,242,,America/Asuncion,BFA,PY,,,,AP
-BFB,,Blue Fox Bay,58.183334,-152.13333,262,,America/Anchorage,BFB,US,,,,AP
 BFC,YBMD,Bloomfield,-15.8736,145.3300018,59,,Australia/Brisbane,BFC,AU,,,,AP
 BFD,KBFD,Bradford Airport,41.802223,-78.63944,2125,,America/New_York,BFD,US,Bradford,Pennsylvania,McKean County,AP
 BFE,EDLI,Bielefeld,52.016666,8.55,351,http://www.flugplatz-bielefeld.de/,Europe/Berlin,BFE,DE,Bielefeld,North Rhine-Westphalia,Regierungsbezirk Detmold,AP
@@ -731,7 +716,6 @@ BGY,LIME,Orio al Serio International Airport,45.670959249999996,9.69876347135455
 BGZ,LPBR,Braga,41.55,-8.433333,531,http://www.pelicano.com.pt/zp_braga.html,Europe/Lisbon,BGZ,PT,Braga,Braga,Braga,AP
 BHA,SESV,Bahia De Caraquez,-0.6,-80.416664,0,,America/Guayaquil,BHA,EC,Bahia de Caraquez,Manabi,,AP
 BHB,KBHB,Bar Harbor Airport,44.44889,-68.361664,65,,America/New_York,BHB,US,Trenton,Maine,Hancock County,AP
-BHC,,Bhurban Heliport,33.925,73.433334,5925,,Asia/Karachi,BHC,PK,Murree,Punjab,,AP
 BHD,EGAC,George Best Belfast City Airport,54.620329350000006,-5.869819381345107,42,http://www.belfastcityairport.com/,Europe/London,BFS,GB,Castlereagh,Northern Ireland,Castlereagh District,AP
 BHE,NZWB,Woodbourne Airport,-41.5172616,173.86935377852836,88,,Pacific/Auckland,BHE,NZ,Blenheim,Marlborough,Marlborough District,AP
 BHF,,Bahia Cupica,6.6940746,-77.4946873,36,,America/Bogota,BHF,CO,,,,AP
@@ -913,7 +897,6 @@ BOB,NTTB,Motu Mute Airport,-16.444335350000003,-151.75254418187558,16,,Pacific/T
 BOC,MPBO,Bocas Del Toro,9.3404691,-82.25481515647917,16,,America/Panama,BOC,PA,Bocas del Toro,Bocas del Toro,,AP
 BOD,LFBD,Bordeaux Airport,44.83102,-0.70217,226,https://www.bordeaux.aeroport.fr/,Europe/Paris,BOD,FR,Le Haillan,Aquitaine,Departement de la Gironde,AP
 BOE,FCOB,Boundji,-1.033333,15.383333,1148,,Africa/Brazzaville,BOE,CG,,,,AP
-BOF,,Bolling AFB,38.9,-77.03333,108,,America/New_York,WAS,US,,,,AP
 BOG,SKBO,El Dorado International Airport,4.7028947500000005,-74.1487499180044,8382,,America/Bogota,BOG,CO,Funza,Cundinamarca,,AP
 BOH,EGHH,Bournemouth Airport,50.78234165,-1.8383330379835439,29,http://www.bournemouthairport.com/,Europe/London,BOH,GB,St Leonards,England,Dorset,AP
 BOI,KBOI,Boise Air Terminal (Gowen Field),43.569263,-116.22193,2860,http://www.cityofboise.org/departments/airport/,America/Boise,BOI,US,Boise,Idaho,Ada County,AP
@@ -949,7 +932,6 @@ BPM,VOHY,Begumpet,17.454031399999998,78.46967295140705,1719,,Asia/Kolkata,HYD,IN
 BPN,WALL,Sultan Aji Muhamad Sulaiman Airport,-1.260623,116.90082,32,http://sepinggan-airport.com/,Asia/Makassar,BPN,ID,City of Balikpapan,East Kalimantan,,AP
 BPS,SBPS,Porto Seguro Airport,-16.4389835,-39.08336724314525,134,,America/Bahia,BPS,BR,Porto Seguro,Bahia,Porto Seguro,AP
 BPT,KBPT,Jefferson County Airport,29.950832,-94.02,22,,America/Chicago,BPT,US,Nederland,Texas,Jefferson County,AP
-BPU,,Beppu,33.25,131.5,1108,,Asia/Tokyo,BPU,JP,Beppu,Oita,,AP
 BPX,ZUBD,Bangda Airport,30.551130399999998,97.10917357409966,14229,,Asia/Shanghai,BPX,CN,Yanduo,Tibet Autonomous Region,,AP
 BPY,FMNQ,Besalampy,-16.7452789,44.4803872,108,,Indian/Antananarivo,BPY,MG,,,,AP
 BQA,RPUR,Baler,15.0,121.083336,590,,Asia/Manila,BQA,PH,Dona Remedios Trinidad,Central Luzon,Province of Bulacan,AP
@@ -974,7 +956,6 @@ BRB,SSRS,Barreirinhas,-2.7574806,-42.80350775032719,55,,America/Fortaleza,BRB,BR
 BRC,SAZS,San Carlos de Bariloche International Airport,-41.145966,-71.16109,2788,http://www.aa2000.com.ar/bariloche,America/Argentina/Salta,BRC,AR,San Carlos de Bariloche,Rio Negro,Departamento de Bariloche,AP
 BRD,KBRD,Crow Wing County Airport,46.40507465,-94.12827992568421,1233,http://brainerdairport.com/,America/Chicago,BRD,US,Brainerd,Minnesota,Crow Wing County,AP
 BRE,EDDW,Bremen Airport,53.0453419,8.789641688895548,49,,Europe/Berlin,BRE,DE,Bremen,Bremen,,AP
-BRF,,Bradford,53.8,-1.75,301,,Europe/London,LBA,GB,Bradford,England,Bradford,AP
 BRG,,Municipal,37.11667,-82.833336,1220,,America/New_York,BRG,US,Whitesburg,Kentucky,Letcher County,AP
 BRH,,Brahman,-5.7,145.36667,396,,Pacific/Port_Moresby,BRH,PG,,,,AP
 BRI,LIBD,Palese Airport,41.1534,16.7656,88,http://www.seap-puglia.it/default.asp?idlingua=2&idcontenuto=25,Europe/Rome,BRI,IT,San Paolo,Apulia,Provincia di Bari,AP
@@ -1002,7 +983,6 @@ BSD,ZPBS,Baoshan Airport,25.05160185,99.16459538074838,5456,,Asia/Shanghai,BSD,C
 BSE,WBGN,Sematan,1.81320515,109.76441012827749,65,,Asia/Kuching,BSE,MY,,,,AP
 BSF,PHSF,Bradshaw AAF,21.383333,-157.75,118,,Pacific/Honolulu,BSF,US,Kailua,Hawaii,Honolulu County,AP
 BSG,FGBT,Bata Airport,1.9093582,9.80749101607464,19,,Africa/Malabo,BSG,GQ,Bata,Litoral,,AP
-BSH,,Brighton,50.816666,-0.116667,88,,Europe/London,BSH,GB,Brighton,England,Brighton and Hove,AP
 BSI,RPLE,Blairsville,40.45,-79.28333,1023,,America/New_York,BSI,US,Blairsville,Pennsylvania,Indiana County,AP
 BSJ,YBNS,Bairnsdale,-37.833332,147.63333,32,,Australia/Melbourne,BSJ,AU,Bairnsdale,Victoria,East Gippsland,AP
 BSK,DAUB,Biskra Airport,34.7931774,5.734029338102971,226,,Africa/Algiers,BSK,DZ,Biskra,Biskra,,AP
@@ -1180,7 +1160,6 @@ BZN,KBZN,Bozeman Yellowstone International Airport,45.78359005,-111.156979627834
 BZO,LIPB,Bolzano,46.46006215,11.326085809111088,744,http://www.abd-airport.it/en/home.htm,Europe/Rome,BZO,IT,San Giacomo,Trentino-Alto Adige,Bolzano,AP
 BZP,YBIZ,Bizant,-15.216667,144.63333,190,,Australia/Brisbane,BZP,AU,,,,AP
 BZR,LFMU,Beziers Vias Airport,43.324165,3.354444,32,,Europe/Paris,BZR,FR,Portiragnes,Languedoc-Roussillon,Departement de l'Herault,AP
-BZS,,Buzzards Pt S,38.863335,-77.013336,36,,America/New_York,WAS,US,,,,AP
 BZT,2TE0,Eagle Air Park,34.89139607951,-114.61603755344,475,,America/Phoenix,BZT,US,Brazoria,Texas,Brazoria County,AP
 BZU,FZKJ,Buta,2.8,24.733334,1335,,Africa/Lubumbashi,BZU,CD,Buta,Eastern Province,,AP
 BZV,FCBB,Maya Maya Airport,-4.2509559,15.253938331362257,974,,Africa/Brazzaville,BZV,CG,Brazzaville,Brazzaville,,AP
@@ -1205,7 +1184,6 @@ CAO,KCAO,Clayton,36.45,-103.183334,5062,,America/Denver,CAO,US,Clayton,New Mexic
 CAP,MTCH,Cap Haitien Airport,19.7263503,-72.20026715140995,45,,America/Port-au-Prince,CAP,HT,Okap,Nord,,AP
 CAQ,SKCU,Caucasia,7.6,-75.25,492,,America/Bogota,CAQ,CO,Caceres,Antioquia,,AP
 CAR,KCAR,Municipal,46.86667,-68.01667,574,,America/New_York,CAR,US,Caribou,Maine,Aroostook County,AP
-CAS,,Anfa,33.559723,-7.663056,154,,Africa/Casablanca,CAS,MA,Casablanca,Grand Casablanca,Casablanca,AP
 CAT,LPCS,Cascais Municipal Aerodrome,38.725,-9.35523,295,http://aerodromo-cascais.pt/?lang=en,Europe/Lisbon,CAT,PT,Lisbon,,,AP
 CAU,SNRU,Caruaru,-8.25,-35.916668,1932,,America/Recife,CAU,BR,Caruaru,Pernambuco,Caruaru,AP
 CAV,FNCZ,Cazombo,-11.9,22.866667,3664,,Africa/Luanda,CAV,AO,,,,AP
@@ -1213,7 +1191,6 @@ CAW,SBCP,Bartolomeu Lisandro Airport,-21.75,-41.3,32,http://www.infraero.gov.br/
 CAX,EGNC,Carlisle,54.93846675,-2.808367404657008,141,,Europe/London,CAX,GB,Brampton,England,Cumbria,AP
 CAY,SOCA,Felix Eboue Airport,4.820737449999999,-52.36305702364213,9,,America/Cayenne,CAY,GF,Matoury,Guyane,Guyane,AP
 CAZ,YCBA,Cobar,-31.53967255,145.79695608947588,738,,Australia/Sydney,CAZ,AU,Cobar,New South Wales,Cobar,AP
-CBA,,Corner Bay,57.716667,-135.2,242,,America/Sitka,CBA,US,,,,AP
 CBB,SLCB,J Wilsterman Airport,-17.413954,-66.178894,8421,,America/La_Paz,CBB,BO,Cochabamba,Cochabamba,,AP
 CBC,,Cherrabun,-18.916668,125.55,538,,Australia/Perth,CBC,AU,,,,AP
 CBD,VOCX,Car Nicobar,9.156225,92.8215167,26,,Asia/Kolkata,CBD,IN,,,,AP
@@ -1242,7 +1219,6 @@ CBZ,,Cabin Creek,55.38333,-132.41667,843,,America/Sitka,CBZ,US,,,,AP
 CCA,SLCH,Chaffee AFB,35.316666,-94.3,482,,America/Chicago,CCA,US,,,,AP
 CCB,KCCB,Cable Airport,34.11242505,-117.6853957695332,1414,,America/Los_Angeles,CCB,US,Claremont,California,Los Angeles County,AP
 CCC,MUCC,Jardines del Rey Airport,22.5125,-78.50833,29,,America/Havana,CCC,CU,Moron,Ciego de Avila,,AP
-CCD,,Century City,34.066666,-118.26667,400,,America/Los_Angeles,LAX,US,,,,AP
 CCE,HECP,Grand Case,18.05,-63.11667,52,http://www.avit.com.eg/index.php/projects/item/138-katameya-airport,America/Marigot,SFG,MF,,,,AP
 CCF,LFMK,Carcassonne Airport,43.216667,2.316667,370,,Europe/Paris,CCF,FR,Pennautier,Languedoc-Roussillon,Departement de l'Aude,AP
 CCG,E13,Crane County Airport,31.41140455,-102.35929573280173,2552,,America/Chicago,CCG,US,Crane,Texas,Crane County,AP
@@ -1255,7 +1231,6 @@ CCM,SBCM,Criciuma,-28.7,-49.36667,203,,America/Sao_Paulo,CCM,BR,Criciuma,Santa C
 CCN,OACC,Chakcharan,34.533333,65.26667,7516,,Asia/Kabul,CCN,AF,Fayroz Koh,Ghowr,,AP
 CCO,SKCI,Carimagua,4.56417,-71.3364,544,,America/Bogota,CCO,CO,,,,AP
 CCP,SCIE,Carriel Sur Airport,-36.77378175,-73.06006863839588,22,,America/Santiago,CCP,CL,Concepcion,Biobio,Provincia de Concepcion,AP
-CCQ,,Cachoeira,-12.6,-38.966667,127,,America/Bahia,CCQ,BR,Cachoeira,Bahia,Cachoeira,AP
 CCR,KCCR,Buchanan Field,37.98926635,-122.05593807253744,39,,America/Los_Angeles,CCR,US,Pacheco,California,Contra Costa County,AP
 CCS,SVMI,Simon Bolivar International Airport,10.60316215,-66.99667670060362,209,http://www.aeropuerto-maiquetia.com.ve/web/,America/Caracas,CCS,VE,Catia La Mar,Vargas,,AP
 CCT,SA30,Colonia Catriel,-39.5,-68.916664,1269,,America/Argentina/Salta,CCT,AR,Picun Leufu,Neuquen,Departamento de Picun Leufu,AP
@@ -1287,7 +1262,6 @@ CDU,YSCN,Camden,-15.45,124.416664,0,,Australia/Sydney,CDU,AU,,,,AP
 CDV,PACV,Mudhole Smith Airport,60.4916501,-145.47370526084313,26,,America/Anchorage,CDV,US,,,,AP
 CDW,KCDW,Caldwell Wright,40.833332,-74.26667,495,http://flycdw.com/,America/New_York,CDW,US,Caldwell,New Jersey,Essex County,AP
 CDY,RPMU,Cagayan De Sulu,7.0142323,118.49520704033101,134,,Asia/Manila,CDY,PH,Cagayan,Mimaropa,Province of Palawan,AP
-CDZ,,Cadiz,36.533333,-6.3,75,,Europe/Madrid,CDZ,ES,Cadiz,Andalusia,Provincia de Cadiz,AP
 CEA,KCEA,Cessna Aircraft Field,37.7,-97.333336,1338,,America/Chicago,ICT,US,,,,AP
 CEB,RPVM,Mactan-Cebu International Airport,10.310328,123.97927764356774,29,http://www.mactan-cebuairport.com.ph/,Asia/Manila,CEB,PH,Buagsong,Central Visayas,Lapu-Lapu City,AP
 CEC,KCEC,Del Norte County Regional Airport,41.7814506,-124.23807108485695,36,,America/Los_Angeles,CEC,US,Crescent City,California,Del Norte County,AP
@@ -1313,7 +1287,6 @@ CEW,KCEW,Bob Sikes,30.7800302,-86.52231696990623,141,http://www.flycew.com/,Amer
 CEX,AK13,Chena Hot Springs,65.05,-146.16667,1099,,America/Anchorage,CEX,US,,,,AP
 CEY,KCEY,Calloway County,36.61667,-88.316666,501,http://www.murraykyleoakley.com/,America/Chicago,CEY,US,Murray,Kentucky,Calloway County,AP
 CEZ,KCEZ,Montezuma County Airport,37.3043669,-108.6276045,5862,http://www.cityofcortez.com/index.aspx?NID=113,America/Denver,CEZ,US,Cortez,Colorado,Montezuma County,AP
-CFA,,Coffee Point,58.216667,-157.5,0,,America/Anchorage,CFA,US,,,,AP
 CFB,SBCB,Cabo Frio International Airport,-22.923360950000003,-42.076586063102596,26,http://www.grupolibra.com.br/libra-aeroporto/cabo-frio/institucional,America/Sao_Paulo,CFB,BR,Cabo Frio,Rio de Janeiro,Cabo Frio,AP
 CFC,SBCD,Cacador,-26.788347950000002,-50.940058269051605,3339,,America/Sao_Paulo,CFC,BR,Cacador,Santa Catarina,Cacador,AP
 CFD,KCFD,Coulter Field,30.666668,-96.36667,374,http://www.bryantx.gov/coulterairfield/,America/Chicago,CFD,US,Bryan,Texas,Brazos County,AP
@@ -1378,12 +1351,10 @@ CHS,KCHS,Charleston International Airport,32.89929845,-80.03946503050427,42,,Ame
 CHT,NZCI,Karewa,-43.8,-176.35,22,,Pacific/Chatham,CHT,NZ,Waitangi,Chatham Islands,,AP
 CHU,PACH,Chuathbaluk Airport,61.5791016,-159.2160034,160,,America/Anchorage,CHU,US,,,,AP
 CHV,LPCH,Chaves,41.733334,-7.466667,1151,,Europe/Lisbon,CHV,PT,Chaves,Vila Real,Chaves,AP
-CHW,,Jiuhuang,39.85,98.416664,4937,,Asia/Shanghai,CHW,CN,,,,AP
 CHX,MPCH,Changuinola,9.45,-82.45,0,,America/Panama,CHX,PA,Changuinola,Bocas del Toro,Distrito de Changuinola,AP
 CHY,AGGC,Choiseul Bay Airport,-6.713787,156.39856,19,,Pacific/Guadalcanal,CHY,SB,,,,AP
 CHZ,K2S7,State,42.583332,-121.86667,4333,,America/Los_Angeles,CHZ,US,Klamath Falls,Oregon,Klamath County,AP
 CIA,LIRA,Ciampino-G. B. Pastine International Airport,41.799065,12.590987,370,,Europe/Rome,ROM,IT,Ciampino,Latium,Citta metropolitana di Roma Capitale,AP
-CIB,,Ap In The Sky,33.406113,-118.41389,1578,,America/Los_Angeles,AVX,US,,,,AP
 CIC,KCIC,Chico Municipal Airport,39.793971549999995,-121.8547755058414,183,,America/Los_Angeles,CIC,US,Chico,California,Butte County,AP
 CID,KCID,The Eastern Iowa Airport,41.889423,-91.7003,898,,America/Chicago,CID,US,Fairfax,Iowa,Linn County,AP
 CIE,YCOI,Collie,-33.36667,116.13333,666,,Australia/Perth,CIE,AU,Collie,Western Australia,Collie,AP
@@ -1403,7 +1374,6 @@ CIR,KCIR,Cairo,37.0,-89.183334,291,,America/Chicago,CIR,US,Cairo,Illinois,Alexan
 CIS,PCIS,Canton Island,-2.833333,-171.66667,0,,Pacific/Enderbury,CIS,KI,Atafu Village,Atafu,,AP
 CIT,UAII,Shymkent Airport,42.3,69.6,1699,,Asia/Almaty,CIT,KZ,Shymkent,Ongtustik Qazaqstan,,AP
 CIU,KCIU,Chippewa County Airport,46.5,-84.35,606,,America/Detroit,SSM,US,,,,AP
-CIV,,Chomley,55.216667,-132.21666,249,,America/Sitka,CIV,US,,,,AP
 CIW,TVSC,Canouan Island,12.7,-61.316666,0,,America/St_Vincent,CIW,VC,,,,AP
 CIX,SPHI,Cornel Ruiz Airport,-6.789722,-79.83222,52,,America/Lima,CIX,PE,Chiclayo,Lambayeque,Provincia de Chiclayo,AP
 CIY,LICB,Comiso Airport,36.99482985,14.60748814771559,702,http://www.aeroportodicomiso.it/,Europe/Rome,CIY,IT,Comiso,Sicily,Ragusa,AP
@@ -1445,7 +1415,6 @@ CKX,CKX,Chicken,64.06816475,-141.95283887481474,1515,,America/Anchorage,CKX,US,,
 CKY,GUCY,Conakry Airport,9.576551250000001,-13.613075755188323,91,http://www.aeroport-conakry.com/aeroport_international_de_conakry.php,Africa/Conakry,CKY,GN,Conakry,Conakry,,AP
 CKZ,LTBH,Canakkale Airport,40.13450605,26.429690386094045,22,,Europe/Istanbul,CKZ,TR,Canakkale,Canakkale,,AP
 CLA,VGCM,Comilla,23.4370218,91.1880657,26,,Asia/Dhaka,CLA,BD,Comilla,Chittagong,,AP
-CLC,,Metroport,29.556944,-95.1375,59,,America/Chicago,CLC,US,,,,AP
 CLD,KCRQ,McClellan-Palomar Airport,33.12754605000001,-117.2814001459839,291,,America/Los_Angeles,SAN,US,Lake San Marcos,California,San Diego County,AP
 CLE,KCLE,Cleveland Hopkins International Airport,41.406618550000005,-81.85120214358412,761,http://www.clevelandairport.com/,America/New_York,CLE,US,Brook Park,Ohio,Cuyahoga County,AP
 CLG,,Coalinga,36.15,-120.35,659,,America/Los_Angeles,CLG,US,Coalinga,California,Fresno County,AP
@@ -1559,7 +1528,6 @@ CPM,KCPM,Compton,33.894444,-118.24778,82,,America/Los_Angeles,CPM,US,West Rancho
 CPN,,Cape Rodney,-10.179823,148.3790302,22,,Pacific/Port_Moresby,CPN,PG,,,,AP
 CPO,SCAT,Chamonate Airport,-27.29892,-70.414406,994,,America/Santiago,CPO,CL,Copiapo,Atacama,Provincia de Copiapo,AP
 CPP,SCKP,Coposa Airport,-20.75,-68.683333,12391,,America/Santiago,CPP,CL,,,,AP
-CPQ,,International,-22.856462,-47.111595,1919,,America/Sao_Paulo,CPQ,BR,Campinas,Sao Paulo,Campinas,AP
 CPR,KCPR,Casper/Natrona County International Airport,42.9054165,-106.46452637926663,5328,,America/Denver,CPR,US,Mills,Wyoming,Natrona County,AP
 CPS,KCPS,St. Louis Downtown Airport,38.56948535,-90.15194783343586,383,,America/Chicago,STL,US,Cahokia,Illinois,Saint Clair County,AP
 CPT,FACT,Cape Town International Airport,-33.97184585,18.602112520148317,114,http://www.airports.co.za/home.asp?pid=229,Africa/Johannesburg,CPT,ZA,Lansdowne,Western Cape,City of Cape Town,AP
@@ -1608,7 +1576,6 @@ CSF,LFPC,Creil,49.2514148,2.5145065264394058,262,,Europe/Paris,CSF,FR,Creil,Pica
 CSG,KCSG,Columbus Airport,32.466667,-84.98333,252,,America/New_York,CSG,US,,,,AP
 CSH,ULAS,Solovky,65.02944,35.733334,32,,Europe/Moscow,CSH,RU,Rabocheostrovsk,Republic of Karelia,,AP
 CSI,YCAS,Casino,-28.880727450000002,153.05894080670998,68,,Australia/Sydney,CSI,AU,Casino,New South Wales,Richmond Valley,AP
-CSJ,,Cape St Jacques,10.033333,111.0,0,,Asia/Ho_Chi_Minh,CSJ,VN,Phu Quy,Binh Thuan,,AP
 CSK,GOGS,Cap Skirring,12.39821835,-16.750892885762433,49,,Africa/Dakar,CSK,SN,Oussouye,Ziguinchor,,AP
 CSM,KCSM,Sherman,35.539165,-96.933334,892,,America/Chicago,CSM,US,Meeker,Oklahoma,Lincoln County,AP
 CSN,KCXP,Carson City,39.194508049999996,-119.74021540263364,4698,http://flycarsoncity.com/,America/Los_Angeles,CSN,US,Carson City,Nevada,Carson City,AP

--- a/airports.csv
+++ b/airports.csv
@@ -3845,12 +3845,10 @@ JTA,SDZG,Pedro Teixeira Castelo Airport,-5.93260025,-40.29597814583012,1457,,Ame
 JTC,SBAE,Bauru-Arealva Airport,-22.15705835,-49.07515943787047,1962,http://www.daesp.sp.gov.br/aeroporto-estadual-de-bauru-arealva-moussa-nakhal-tobias/,America/Sao_Paulo,JTC,BR,Bauru,Sao Paulo,Bauru,AP
 JTI,SWJW,Jatai,-17.829445,-51.774723,2529,,America/Sao_Paulo,JTI,BR,Jatai,Goias,Jatai,AP
 JTN,SDIM,Antônio Ribeiro Nogueira Jr. State Airport,-24.164722,-46.785556,10,,America/Sao_Paulo,JTN,BR,Itanhaém,,,AP
-JTO,,Heliport,34.166668,-118.833336,0,,America/Los_Angeles,JTO,US,Thousand Oaks,California,Ventura County,AP
 JTR,LGSR,Santorini International Airport,36.4,25.483334,127,,Europe/Athens,JTR,GR,Mesaria,South Aegean,Nomos Kykladon,AP
 JTY,LGPL,Astypalaia Airport,36.5771451,26.3800026,165,,Europe/Athens,JTY,GR,Astypalaia,South Aegean,Nomos Dodekanisou,AP
 JUA,SIZX,Juara,-11.333333,-57.466667,870,,America/Cuiaba,JUA,BR,,,,AP
 JUB,HSSJ,Juba International Airport,4.873847,31.598731911290322,1513,,Africa/Juba,JUB,SS,Juba,Central Equatoria,,AP
-JUC,,Universal City Heliport,34.083332,-118.26667,0,,America/Los_Angeles,LAX,US,Silver Lake,California,Los Angeles County,AP
 JUH,ZSJH,Chizhou Jiuhuashan Airport,19.222221,72.84722,60,,Asia/Shanghai,JUH,CN,Borivli,Maharashtra,Mumbai Suburban,AP
 JUI,EDWJ,Juist,53.6816569,7.0556541,7,,Europe/Berlin,JUI,DE,Juist,Lower Saxony,,AP
 JUJ,SASJ,El Cadillal Airport,-24.4,-65.083336,3019,,America/Argentina/Jujuy,JUJ,AR,La Mendieta,Jujuy,,AP
@@ -3858,7 +3856,6 @@ JUL,SPJL,Juliaca Airport,-15.4675198,-70.15719993301872,12552,,America/Lima,JUL,
 JUM,VNJL,Jumla,29.274171000000003,82.1923411641879,7700,,Asia/Kathmandu,JUM,NP,Jumla,Mid Western,Karnali Zone,AP
 JUN,YJDA,Jundah,-24.8359579,143.0609407,145,,Australia/Brisbane,JUN,AU,,,,AP
 JUO,SKJU,Jurado,7.116667,-77.75,2184,,America/Bogota,JUO,CO,Jurado,Choco,,AP
-JUP,,Cable Heliport,34.1,-117.63333,0,,America/Los_Angeles,CCB,US,Upland,California,San Bernardino County,AP
 JUR,YJNB,Jurien Bay,-30.3031808,115.0543855,15,,Australia/Perth,JUR,AU,Jurien Bay,Western Australia,Dandaragan,AP
 JUT,MHJU,Juticalpa,14.673333,-86.29305,1314,,America/Tegucigalpa,JUT,HN,La Concepcion,Olancho,,AP
 JUV,BGUK,Heliport,72.78528,-56.150833,414,,America/Godthab,JUV,GL,,,,AP
@@ -3867,8 +3864,6 @@ JVA,FMMK,Ankavandra,-18.805817,45.2739652,427,,Indian/Antananarivo,JVA,MG,,,,AP
 JVI,47N,Central Jersey Regional Airport,42.783333,-104.61667,86,http://www.centraljerseyairport.com/,America/New_York,JVI,US,,,,AP
 JVL,KJVL,Rock County,42.683334,-89.01667,808,http://www.jvlairport.com/,America/Chicago,JVL,US,Janesville,Wisconsin,Rock County,AP
 JWA,FBJW,Jwaneng,-24.6009592,24.692185516131104,3900,,Africa/Gaborone,JWA,BW,Letlhakeng,Kweneng,,AP
-JWH,,Westchase Hilton Heliport,29.73611,-95.41778,0,,America/Chicago,HOU,US,,,,AP
-JWL,,Woodlawns,30.150557,-95.47139,0,,America/Chicago,HOU,US,The Woodlands,Texas,Montgomery County,AP
 JWN,OITZ,Zanjan,36.771809149999996,48.36540846861334,5382,,Asia/Tehran,JWN,IR,Zanjan,Zanjan,,AP
 JWO,,Jungwon Air Base,37.030101,127.8855023,0,,Asia/Seoul,JWO,KR,Koesan,Chungcheongbuk-do,,AP
 JXA,ZYJX,Jixi Airport,45.306084,130.99675,760,,Asia/Shanghai,JXA,CN,Hongjunlu,Heilongjiang Sheng,,AP
@@ -3883,7 +3878,6 @@ KAD,DNKA,Kaduna Airport,10.595833,7.440278,2073,http://www.faannigeria.org/niger
 KAE,,SPB,56.966667,-133.95,0,,America/Sitka,KAE,US,,,,AP
 KAF,,Karato,-6.283333,155.35,109,,Pacific/Port_Moresby,KAF,PG,,,,AP
 KAG,RKNN,Gangneung,37.763768,128.953031,35,,Asia/Seoul,KAG,KR,,,,AP
-KAH,,City Heliport,-37.816666,144.96666,0,,Australia/Melbourne,MEL,AU,,,,AP
 KAI,SYKA,Kaieteur,5.883333,-60.619446,1520,,America/Guyana,KAI,GY,,,,AP
 KAJ,EFKI,Kajaani Airport,64.2834484,27.6784449,483,https://www.finavia.fi/en/kajaani/,Europe/Helsinki,KAJ,FI,Kajaani,Kainuu,Kajaani,AP
 KAK,,Kar,-4.666667,146.0,4965,,Pacific/Port_Moresby,KAK,PG,,,,AP
@@ -4093,7 +4087,6 @@ KKB,KKB,SPB,58.183334,-152.35,0,,America/Anchorage,KKB,US,,,,AP
 KKC,VTUK,Khon Kaen Airport,16.4662033,102.78522834671722,670,,Asia/Bangkok,KKC,TH,Khon Kaen,Khon Kaen,,AP
 KKD,AYKO,Kokoda,-8.8852451,147.73129469652469,1240,,Pacific/Port_Moresby,KKD,PG,,,,AP
 KKE,NZKK,Kerikeri Airport,-35.25801885,173.911817139377,492,http://www.kerikeri-airport.co.nz/,Pacific/Auckland,KKE,NZ,Kerikeri,Northland,Far North District,AP
-KKF,,Kagvik Creek,67.6,-163.5,0,,America/Nome,KKF,US,,,,AP
 KKG,SYKZ,Konawaruk,5.266667,-59.816666,230,,America/Guyana,KKG,GY,,,,AP
 KKH,PADY,Kongiganak Airport,59.966667,-162.75,30,,America/Nome,KKH,US,,,,AP
 KKI,Z13,Spb,60.906944,-161.42223,23,,America/Anchorage,KKI,US,,,,AP
@@ -4121,7 +4114,6 @@ KLF,UUBC,Grabtsevo Airport,54.546667,36.368889,656,,Europe/Moscow,KLF,RU,Kaluga,
 KLG,PALG,Kalskag Municipal Airport,61.53258,-160.3465,55,,America/Anchorage,KLG,US,,,,AP
 KLH,VAKP,Kolhapur,16.666668,74.333336,1996,,Asia/Kolkata,KLH,IN,Kagal,Maharashtra,Kolhapur,AP
 KLI,FZFP,Kota Koli,-4.166667,21.75,1801,,Africa/Kinshasa,KLI,CD,,,,AP
-KLJ,,Klaipeda,55.424284,21.143408,0,,Europe/Vilnius,PLQ,LT,Neringa,,,AP
 KLK,HKFG,Kalokol,-6.783333,25.783333,1245,,Africa/Nairobi,KLK,KE,,,,AP
 KLL,9Z8,Levelock,59.12690265,-156.86113347994,39,,America/Anchorage,KLL,US,,,,AP
 KLM,OINE,Kalaleh,37.38468075,55.44509053533892,425,,Asia/Tehran,KLM,IR,Kalaleh,Golestan,,AP
@@ -4131,7 +4123,6 @@ KLP,,Kelp Bay,57.55,-134.86667,0,,America/Sitka,KLP,US,,,,AP
 KLQ,WIPV,Keluang,-2.683333,103.9,76,,Asia/Jakarta,KLQ,ID,Sekayu,South Sumatra,,AP
 KLR,ESMQ,Kalmar Oland Airport,56.685,16.287222,17,,Europe/Stockholm,KLR,SE,Rinkabyholm,Kalmar,Kalmar Kommun,AP
 KLS,KKLS,Longview,46.15,-122.9,20,http://www.kelso.gov/Departments%20%2526%20Services/Airport,America/Los_Angeles,KLS,US,,,,AP
-KLT,,Kaiserslautern,49.433334,7.75,0,,Europe/Berlin,KLT,DE,Kaiserslautern,Rheinland-Pfalz,,AP
 KLU,LOWK,Klagenfurt Airport,46.64348185,14.328599613147205,1472,http://www.klagenfurt-airport.com/,Europe/Vienna,KLU,AT,Klagenfurt am Woerthersee,Carinthia,Klagenfurt am Woerthersee,AP
 KLV,LKKV,Karlovy Vary Airport,50.2018781,12.913358570496666,1989,http://www.airport-k-vary.cz/indexEN.php,Europe/Prague,KLV,CZ,Dalovice,Karlovarsky,,AP
 KLW,PAKW,Klawock Airport,55.57910895,-133.07405023974576,80,,America/Sitka,KLW,US,,,,AP
@@ -4183,7 +4174,6 @@ KNR,OIBJ,Jam,27.817524650000003,52.357625547146384,2173,,Asia/Tehran,KNR,IR,Jam,
 KNS,YKII,King Island Airport,-39.877928749999995,143.88268453090632,132,,Australia/Currie,KNS,AU,Currie,Tasmania,King Island,AP
 KNT,KTKX,Municipal,36.230556,-90.03472,262,http://www.ktkx.us/,America/Chicago,KNT,US,Kennett,Missouri,Dunklin County,AP
 KNU,VICX,Kanpur Airport,26.4174559,80.40040718434199,410,,Asia/Kolkata,KNU,IN,Kanpur,Uttar Pradesh,Kanpur,AP
-KNV,,Knights Inlet,50.683334,-125.833336,0,,America/Vancouver,KNV,CA,,,,AP
 KNW,PANW,New Stuyahok,59.4564459,-157.3746663,364,,America/Anchorage,KNW,US,,,,AP
 KNX,YPKU,Kununurra Airport,-15.77628825,128.70522745340165,145,,Australia/Perth,KNX,AU,,,,AP
 KNY,UNKI,Kodinsk Airport,58.4794006,99.0939026,984,,Asia/Krasnoyarsk,KNY,RU,,,,AP
@@ -4216,13 +4206,10 @@ KOZ,,Ouzinkie SPB,57.916668,-152.5,55,,America/Anchorage,KOZ,US,,,,AP
 KPA,AYKG,Kopiago,-5.383333,142.55,4445,,Pacific/Port_Moresby,KPA,PG,,,,AP
 KPB,KPB,Point Baker SPB,56.333332,-133.58333,0,,America/Anchorage,KPB,US,,,,AP
 KPC,PAPC,Port Clarence,65.2534907,-166.8555889,10,,America/Anchorage,KPC,US,,,,AP
-KPD,,King Of Prussia,40.083332,-75.4,0,,America/New_York,KPD,US,King of Prussia,Pennsylvania,Montgomery County,AP
 KPE,AYYP,Yapsiei,-4.05,141.16667,600,,Pacific/Port_Moresby,KPE,PG,,,,AP
 KPF,AYDL,Kondubol,-8.533056,142.51195,132,,Pacific/Port_Moresby,KPF,PG,,,,AP
 KPG,,Kurupung,6.466667,-59.166668,0,,America/Guyana,KPG,GY,,,,AP
-KPH,,Pauloff Harbor SPB,54.45,-162.68333,0,,America/Anchorage,KPH,US,,,,AP
 KPI,WBGP,Kapit,2.0102839,112.9317606,65,,Asia/Kuching,KPI,MY,,,,AP
-KPK,,Parks SPB,57.433613,-153.9,0,,America/Anchorage,KPK,US,,,,AP
 KPL,,Kapal,-8.6303459,142.82360395,170,,Pacific/Port_Moresby,KPL,PG,,,,AP
 KPM,AYAQ,Kompiam,-5.3821271500000005,143.9242469519006,5100,,Pacific/Port_Moresby,KPM,PG,,,,AP
 KPN,PAKI,Kipnuk SPB,59.933334,-164.05,11,,America/Nome,KPN,US,,,,AP
@@ -4259,7 +4246,6 @@ KRR,URKK,Krasnodar International Airport,45.03371395,39.18144291163304,118,http:
 KRS,ENCN,Kristiansand Airport,58.20414355,8.08327172379055,57,http://www.avinor.no/en/airport/kristiansand,Europe/Oslo,KSU,NO,Justvik,Vest-Agder,Kristiansand,AP
 KRT,HSSS,Khartoum International Airport,15.5915979,32.5496203,1265,,Africa/Khartoum,KRT,SD,Khartoum,Khartoum,,AP
 KRU,AYEA,Kerau,-8.2709847,147.07180272949768,7360,,Pacific/Port_Moresby,KRU,PG,,,,AP
-KRV,,Kerio Valley,2.983333,36.11667,4325,,Africa/Nairobi,KRV,KE,,,,AP
 KRW,UTAK,Turkmanbashi Airport,40.083332,53.083332,279,,Asia/Ashgabat,KRW,TM,Turkmenbasy,Balkan,,AP
 KRX,AYKR,Kar Kar,-4.5,145.96666,130,,Pacific/Port_Moresby,KRX,PG,,,,AP
 KRY,ZWKM,Karamay Airport,45.61667,84.88333,0,,Asia/Shanghai,KRY,CN,,,,AP
@@ -4322,8 +4308,6 @@ KUE,AGKU,Kukundu,-8.016667,156.0,32,,Pacific/Guadalcanal,KUE,SB,,,,AP
 KUF,UWWW,Kurumoch International Airport,53.50575105,50.15699388903002,477,http://airport.samara.ru/en/,Europe/Samara,KUF,RU,Bereza,Samara,,AP
 KUG,YKUB,Kubin Island,-10.233333,142.3,15,,Australia/Brisbane,KUG,AU,Kubin,Queensland,Moa Island,AP
 KUH,RJCK,Kushiro Airport,43.04308625,144.19370437389728,327,,Asia/Tokyo,KUH,JP,Kushiro,Hokkaido,,AP
-KUI,,Kawau Island,-36.416668,174.83333,0,,Pacific/Auckland,KUI,NZ,Warkworth,Auckland,Auckland,AP
-KUJ,,Kushimoto,33.433334,135.78334,0,,Asia/Tokyo,KUJ,JP,Shingu,Wakayama,,AP
 KUK,PFKA,Kasigluk Airport,60.8723835,-162.52453842216684,48,,America/Nome,KUK,US,,,,AP
 KUL,WMKK,Kuala Lumpur International Airport,2.74476355,101.7066224803332,69,http://www.klia.com.my,Asia/Kuala_Lumpur,KUL,MY,Kampung Baharu Nilai,Negeri Sembilan,,AP
 KUM,RJFC,Yakushima Airport,30.38751365,130.6567876840263,124,,Asia/Tokyo,KUM,JP,,,,AP
@@ -4336,10 +4320,8 @@ KUS,BGKK,Kulusuk Airport,65.57415205000001,-37.124473406699465,117,,America/Godt
 KUT,UGKO,Kutaisi International Airport,42.25,42.7,223,,Asia/Tbilisi,KUT,GE,Kutaisi,Imereti,,AP
 KUU,VIBR,Bhuntar Airport,31.983334,77.1,3573,,Asia/Kolkata,KUU,IN,Kulu,Himachal Pradesh,Kulu,AP
 KUV,RKJK,Gunsan Airport,35.983334,126.75,29,,Asia/Seoul,KUV,KR,Kunsan,Jeollabuk-do,,AP
-KUW,,Kugururok River,67.96667,-161.98334,0,,America/Anchorage,KUW,US,,,,AP
 KUX,AYUY,Kuyol,-5.3717997,141.62561895159217,3290,,Pacific/Port_Moresby,KUX,PG,,,,AP
 KUY,AYKS,Kamusi Airport,-7.42071535,143.12189263481963,97,,Pacific/Port_Moresby,KUY,PG,,,,AP
-KUZ,,Gunsan Airbase,37.716667,128.81667,0,,Asia/Seoul,KUZ,KR,Kang-neung,Gangwon-do,,AP
 KVA,LGKV,Kavala International Airport,40.914999300000005,24.61461321003228,18,,Europe/Athens,KVA,GR,Nea Karya,East Macedonia and Thrace,Nomos Kavalas,AP
 KVB,ESGR,Skovde,58.4561111,13.9727778,324,,Europe/Stockholm,KVB,SE,Stopen,Vaestra Goetaland,Skovde Kommun,AP
 KVC,PAVC,King Cove,55.055,-162.31334,155,,America/Nome,KVC,US,,,,AP
@@ -4370,7 +4352,6 @@ KWP,KWP,Village SPB,57.766945,-153.55,0,,America/Anchorage,KWP,US,,,,AP
 KWR,,Kwai Harbour,-8.566667,160.73334,0,,Pacific/Guadalcanal,KWR,SB,,,,AP
 KWS,AGKW,Kwailabesi Aerodrom,41.350193,-71.8069,52,,Pacific/Guadalcanal,KWS,SB,,,,AP
 KWT,PFKW,Kwethluk Airport,60.7931676,-161.4412536,25,,America/Anchorage,KWT,US,,,,AP
-KWU,,Mansion House,22.316668,114.21667,0,,Pacific/Auckland,KWU,NZ,Kowloon,Kowloon City,,AP
 KWV,,Kurwina,-6.183333,155.33333,65,,Pacific/Port_Moresby,KWV,PG,,,,AP
 KWX,,Kiwai Island,-8.583333,143.41667,30,,Pacific/Port_Moresby,KWX,PG,,,,AP
 KWY,,Kiwayu,-2.016667,41.266666,21,,Africa/Nairobi,KWY,KE,,,,AP
@@ -4391,8 +4372,6 @@ KYE,OLKA,Kleyate,34.58611,36.002777,75,,Asia/Beirut,KYE,LB,Halba,Aakkar,,AP
 KYF,YYLR,Yeelirrie,-27.2833004,120.0830002,0,,Australia/Perth,KYF,AU,,,,AP
 KYI,YYTA,Yalata Mission,-31.46916915,131.82077058060463,0,,Australia/Adelaide,KYI,AU,,,,AP
 KYK,PAKY,Karluk,57.5661517,-154.4515784,137,,America/Anchorage,KYK,US,,,,AP
-KYL,,Port Largo,25.066668,-80.46667,0,,America/New_York,KYL,US,Key Largo,Florida,Monroe County,AP
-KYN,,Milton Keynes,52.03428,-0.774107,0,,Europe/London,KYN,GB,Loughton,England,Milton Keynes,AP
 KYO,X39,Topp Of Tampa,28.216667,-82.36667,68,http://www.tampanorth.com/,America/New_York,TPA,US,Wesley Chapel,Florida,Pasco County,AP
 KYP,VYKP,Kyaukpyu Airport,19.42229405,93.53527784349123,20,,Asia/Rangoon,KYP,MM,,,,AP
 KYS,GAKY,Kayes,14.431944,-11.439444,164,,Africa/Bamako,KYS,ML,Kayes,Kayes,,AP
@@ -4405,7 +4384,6 @@ KZC,VDKH,Kompong-Chhna,12.333333,104.583336,56,,Asia/Phnom_Penh,KZC,KH,Kampong C
 KZD,VDSY,Krakor,12.533333,104.2,62,,Asia/Phnom_Penh,KZD,KH,Pursat,Pursat,,AP
 KZF,AYKT,Kaintiba,-7.466667,146.0,2050,,Pacific/Port_Moresby,KZF,PG,,,,AP
 KZG,EDGY,Kitzingen,49.743484949999996,10.203628630722946,689,https://www.flugplatz-kitzingen.de/,Europe/Berlin,KZG,DE,Kitzingen,Bavaria,Regierungsbezirk Unterfranken,AP
-KZH,,Kizhuyak,57.583332,-153.15,0,,America/Anchorage,KZH,US,,,,AP
 KZI,LGKZ,Philippos Airport,40.28699355,21.841440993464275,2059,,Europe/Athens,KZI,GR,Krokos,West Macedonia,Nomos Kozanis,AP
 KZN,UWKD,Kazan International Airport,55.60740975,49.28551379228139,411,http://www.kazan.aero/en/,Europe/Moscow,KZN,RU,Stolbishchi,Tatarstan,,AP
 KZO,UAOO,Kzyl-Orda Airport,44.705641299999996,65.58855590395623,433,,Asia/Qyzylorda,KZO,KZ,Tasboget,Qyzylorda,,AP
@@ -4417,7 +4395,6 @@ LAC,,Layang-Layang Airstrip,7.4,113.85,7,,Asia/Kuching,LAC,MY,,,,AP
 LAD,FNLU,Quatro de Fevereiro Airport,-8.847951,13.234862,243,,Africa/Luanda,LAD,AO,Luanda,Luanda,,AP
 LAE,AYNZ,Nadzab Airport,-6.5684807,146.72620196586914,239,,Pacific/Port_Moresby,LAE,PG,,,,AP
 LAF,KLAF,Purdue University,40.4122378,-86.9392955985291,606,,America/Indiana/Indianapolis,LAF,US,West Lafayette,Indiana,Tippecanoe County,AP
-LAG,,La Guaira,10.6,-66.933334,0,,America/Caracas,LAG,VE,La Guaira,Vargas,Municipio Vargas,AP
 LAH,WAEL,Labuha,-0.63359055,127.50552915228928,49,,Asia/Jayapura,LAH,ID,Labuha,Maluku Utara,,AP
 LAI,LFRO,Servel Airport,48.754166,-3.481944,290,http://www.lannion.aeroport.fr,Europe/Paris,LAI,FR,Lannion,Brittany,Departement des Cotes-d'Armor,AP
 LAJ,SBLJ,Correia Pinto Airport,-27.8,-50.316666,3065,,America/Sao_Paulo,LAJ,BR,Lages,Santa Catarina,Lages,AP
@@ -4430,9 +4407,7 @@ LAP,MMLP,Leon Airport,24.076088,-110.367836,69,http://aeropuertosgap.com.mx/aero
 LAQ,HLLQ,La Braq Airport,32.788612,21.964167,2157,,Africa/Tripoli,LAQ,LY,Al Bayda',Al Jabal al Akhdar,,AP
 LAR,KLAR,General Brees Field,41.31361,-105.67306,7284,,America/Denver,LAR,US,Laramie,Wyoming,Albany County,AP
 LAS,KLAS,McCarran International Airport,36.0861034,-115.16111989849915,2181,http://www.mccarran.com/,America/Los_Angeles,LAS,US,,,,AP
-LAT,,La Uribe,4.75,-74.05,0,,America/Bogota,LAT,CO,Cota,Cundinamarca,,AP
 LAU,HKLU,Lamu,-2.25,40.911667,20,http://www.kenyaairports.co.ke/kaa/airports/airstrips/manda_intro.html,Africa/Nairobi,LAU,KE,Lamu,Lamu,,AP
-LAV,,Lalomalava,-14.016667,-171.73334,0,,Pacific/Apia,LAV,WS,Matavai,,,AP
 LAW,KLAW,Lawton-Fort Sill Regional Airport,34.569849500000004,-98.41812229900623,1110,,America/Chicago,LAW,US,Lawton,Oklahoma,Comanche County,AP
 LAX,KLAX,Los Angeles International Airport,33.94216754999999,-118.42139298414197,125,https://www.flylax.com/,America/Los_Angeles,LAX,US,El Segundo,California,Los Angeles County,AP
 LAY,FALY,Ladysmith,-28.580999300000002,29.751201906708054,3548,,Africa/Johannesburg,LAY,ZA,Ladysmith,KwaZulu-Natal,uThukela District Municipality,AP

--- a/airports.csv
+++ b/airports.csv
@@ -3210,7 +3210,6 @@ HOG,MUHG,Frank Pais Airport,20.785278,-76.315,308,,America/Havana,HOG,CU,Cacocum
 HOH,LOIH,Hohenems-Dornbirn,47.3844036,9.699329804822927,1328,http://www.loih.at/,Europe/Vienna,HOH,AT,,,,AP
 HOI,NTTO,Hao Island,-18.06248,-140.96529,6,,Pacific/Tahiti,HOI,PF,,,,AP
 HOK,YHOO,Hooker Creek,-18.3312301,130.65502900523728,1000,,Australia/Darwin,HOK,AU,,,,AP
-HOL,,Holikachu,62.86667,-159.65,55,,America/Anchorage,HOL,US,,,,AP
 HOM,PAHO,Homer Airport,59.6429186,-151.4905296,68,,America/Anchorage,HOM,US,,,,AP
 HON,KHON,Howes,44.38361,-98.22639,1269,,America/Chicago,HON,US,Huron,South Dakota,Beadle County,AP
 HOO,,Nhon Co,12.009722,107.68806,1958,,Asia/Ho_Chi_Minh,HOO,VN,Gia Nghia,Dak Nong,,AP
@@ -3221,7 +3220,6 @@ HOS,SAHC,Oscar Reguera,-37.416668,-70.21667,2680,,America/Argentina/Salta,HOS,AR
 HOT,KHOT,Memorial Field,34.4826632,-93.09566931295522,524,,America/Chicago,HOT,US,Piney,Arkansas,Garland County,AP
 HOU,KHOU,William P. Hobby Airport,29.64714905,-95.27692608634595,49,http://www.fly2houston.com/hobbyHome,America/Chicago,HOU,US,,,,AP
 HOV,ENOV,Hovden Airport,62.17820605,6.068381079971115,249,https://avinor.no/en/airport/orsta-volda-airport/,Europe/Oslo,HOV,NO,Volda,More og Romsdal,Volda,AP
-HOW,,Howard AFB,8.92006357521,-79.59463331569,39,,America/Panama,HOW,PA,,,,AP
 HOX,VYHL,Homalin Airport,24.899037149999998,94.91514266572523,511,,Asia/Rangoon,HOX,MM,Yairipok,Manipur,Thoubal,AP
 HOY,,Hoy Island,58.833332,-3.3,731,,Europe/London,HOY,GB,Stromness,Scotland,Orkney Islands,AP
 HPA,NFTL,Salote Pilolevu,-19.776888200000002,-174.3414548343137,26,,Pacific/Tongatapu,HPA,TO,Pangai,Ha`apai,,AP
@@ -3244,11 +3242,9 @@ HRF,VRAH,Hoarafushi Airport,6.980556,72.895833,19,http://www.macl.aero/,Indian/M
 HRG,HEGN,Hurghada International Airport,27.1798365,33.79432766304178,82,,Africa/Cairo,HRG,EG,Hurghada,Red Sea,,AP
 HRH,VIAH,Aligarh Airport,27.8592,78.1487,619,,Asia/Kolkata,HRH,IN,,,,AP
 HRI,VCRI,Mattala Rajapaksa International Airport,6.28627825,81.1225232733857,137,http://www.mria.lk/,Asia/Colombo,HRI,LK,,,,AP
-HRJ,,Chaurjhari,28.0,82.333336,2437,,Asia/Kathmandu,HRJ,NP,Tulsipur,Mid Western,,AP
 HRK,UKHH,Kharkov Airport,49.92078,36.281185,469,http://www.airport.kharkov.ua/,Europe/Kiev,HRK,UA,Bezlyudivka,Kharkiv,,AP
 HRL,KHRL,Valley International Airport,26.231114849999997,-97.65348464393676,29,,America/Chicago,HRL,US,Harlingen,Texas,Cameron County,AP
 HRM,DAFH,Tilrempt,33.166668,3.2,2621,,Africa/Algiers,HRM,DZ,Berriane,Ghardaia,,AP
-HRN,,Heliport,-23.433332,151.91667,0,,Australia/Brisbane,HRN,AU,Gladstone,Queensland,Gladstone,AP
 HRO,KHRO,Boone County Airport,36.26118925,-93.15402100590016,1351,,America/Chicago,HRO,US,Harrison,Arkansas,Boone County,AP
 HRR,,Herrera,3.216667,-75.85,8139,,America/Bogota,HRR,CO,,,,AP
 HRS,FAHR,Harrismith Airport,-26.233334,29.1,5196,,Africa/Johannesburg,HRS,ZA,Kriel,Mpumalanga,Nkangala District Municipality,AP
@@ -3274,7 +3270,6 @@ HST,KHST,AFB,25.483334,-80.48333,39,http://www.homestead.afrc.af.mil/,America/Ne
 HSV,KHSV,Huntsville International Airport,34.63699305,-86.76383388377238,583,http://www.flyhuntsville.com/portal/#.VbaG-_lVhBc,America/Chicago,HSV,US,Madison,Alabama,Madison County,AP
 HSZ,RCPO,Hsinchu,24.818723900000002,120.94343356118459,29,,Asia/Taipei,HSZ,TW,Hsinchu,Taiwan,Hsinchu,AP
 HTA,UIAA,Chita Airport,52.02481615,113.31022128113224,2188,http://aerochita.ru/,Asia/Chita,HTA,RU,Domna,Transbaikal Territory,,AP
-HTB,,Terre-de-Bas,15.716667,-61.63333,0,,America/Guadeloupe,HTB,GP,,,,AP
 HTG,UOHH,Hatanga Airport,71.97928245,102.51148804695876,49,,Asia/Krasnoyarsk,HTG,RU,Khatanga,Krasnoyarskiy,,AP
 HTH,KHTH,Hawthorne,38.533333,-118.63333,4245,,America/Los_Angeles,HTH,US,Hawthorne,Nevada,Mineral County,AP
 HTI,YBHM,Hamilton Island Airport,-20.3522845,148.9480748,16,http://www.hamiltonisland.com.au/airport/,Australia/Lindeman,HTI,AU,,,,AP
@@ -3381,7 +3376,6 @@ ICK,SMNI,Nieuw Nickerie,5.933333,-56.983334,78,,America/Paramaribo,ICK,SR,Nieuw 
 ICL,KICL,Municipal,40.733334,-95.03333,997,,America/Chicago,ICL,US,Clarinda,Iowa,Page County,AP
 ICN,RKSI,Incheon International Airport,37.4634169,126.44164409450852,55,,Asia/Seoul,SEL,KR,,,,AP
 ICO,,Sicogon Island,11.4593295,123.2505409,32,,Asia/Manila,ICO,PH,San Fernando,Western Visayas,Province of Iloilo,AP
-ICR,,Nicaro,20.983334,-75.975,423,,America/Havana,ICR,CU,Gibara,Holguin,,AP
 ICS,KU70,Cascade,44.492787,-116.0151769717505,4708,,America/Boise,ICS,US,Cascade,Idaho,Valley County,AP
 ICT,KICT,Wichita Dwight D. Eisenhower National Airport,37.65333905,-97.43088979155792,1338,,America/Chicago,ICT,US,Wichita,Kansas,Sedgwick County,AP
 ICY,19AK,Icy Bay,60.0,-141.25,82,,America/Anchorage,ICY,US,,,,AP
@@ -3425,7 +3419,6 @@ IGR,SARI,Cataratas del Iguazu International Airport,-25.736028150000003,-54.4747
 IGS,ETSI,Ingolstadt-manching,48.713641249999995,11.535868767571744,1190,,Europe/Berlin,IGS,DE,Manching,Bavaria,Upper Bavaria,AP
 IGT,URMS,Magas Airport,43.31963055,45.02122159240803,1141,,Europe/Moscow,IGT,RU,Troitskaya,Ingushetiya,,AP
 IGU,SBFI,Cataratas International Airport,-25.5930616,-54.49060873125,757,,America/Sao_Paulo,IGU,BR,Puerto Iguazu,Misiones,Departamento de Iguazu,AP
-IHA,,Niihama,33.916668,133.26666,242,,Asia/Tokyo,IHA,JP,Niihama,Ehime,,AP
 IHC,FQIA,Inhaca,-25.99802725,32.929576339642985,59,,Africa/Maputo,IHC,MZ,,,,AP
 IHN,OYQN,Qishn,15.05,50.05,1302,,Asia/Aden,IHN,YE,Ad Dis ash Sharqiyah,Muhafazat Hadramawt,Ad Dis,AP
 IHO,FMSI,Ihosy,-22.416668,46.11667,2322,,Indian/Antananarivo,IHO,MG,Ihosy,Ihorombe,,AP
@@ -3433,14 +3426,12 @@ IHR,OIZI,Iran Shahr,27.228365,60.71806,1942,,Asia/Tehran,IHR,IR,Iranshahr,Sistan
 IHU,AYIH,Ihu,-7.898111050000001,145.39741327631762,26,,Pacific/Port_Moresby,IHU,PG,,,,AP
 IIA,EIMN,Inishmaan,53.093722650000004,-9.569016248449334,26,,Europe/Dublin,IIA,IE,,,,AP
 IIL,OICI,Ilaam Airport,33.58637,46.399235,4343,,Asia/Tehran,IIL,IR,Ilam,Ilam,,AP
-IIN,,Nishinoomote,30.716667,130.98334,68,,Asia/Tokyo,IIN,JP,,,,AP
 IIS,AYIA,Nissan Island,-4.333333,154.34166,0,,Pacific/Port_Moresby,IIS,PG,,,,AP
 IJK,USII,Izhevsk Airport,56.836190450000004,53.463128329289745,406,,Europe/Samara,IJK,RU,Khokhryaki,Udmurtiya,,AP
 IJU,SSIJ,J. Batista Bos Filho Airport,-28.416668,-53.916668,1227,,America/Sao_Paulo,IJU,BR,Ijui,Rio Grande do Sul,Ijui,AP
 IJX,,Municipal,39.774166,-90.23722,606,,America/Chicago,IJX,US,Jacksonville,Illinois,Morgan County,AP
 IKA,OIIE,Imam Khomeini International Airport,35.4164909,51.144760916142786,3261,http://www.ikia.ir/,Asia/Tehran,THR,IR,Robat Karim,Tehran,,AP
 IKB,KUKF,Wilkes County,36.15,-81.15,1010,http://wilkescounty.net/airport/,America/New_York,IKB,US,North Wilkesboro,North Carolina,Wilkes County,AP
-IKE,UEST,Tiksi Airport,71.6975,128.902778,26,,Asia/Yakutsk,IKE,RU,,,,AP
 IKI,RJDB,Iki Airport,33.749026,129.785263,32,,Asia/Tokyo,IKI,JP,Karatsu,Saga Prefecture,,AP
 IKK,KIKK,Greater Kankakee,41.38333,-88.25,501,http://kvaa.com/,America/Chicago,IKK,US,Channahon,Illinois,Will County,AP
 IKL,FZGV,Ikela,-1.666667,23.666668,1584,,Africa/Kinshasa,IKL,CD,,,,AP
@@ -3450,7 +3441,6 @@ IKS,UEST,Tiksi Airport,71.69780095,128.89743950212954,26,,Asia/Yakutsk,IKS,RU,Ti
 IKT,UIII,Irkutsk International Airport,52.273308,104.35607,1594,http://www.iktport.ru/,Asia/Irkutsk,IKT,RU,Dzerzhinsk,Irkutsk,,AP
 IKU,UCFL,Issyk-Kul International Airport,42.58600115,76.70732070846512,5416,http://www.airport.kg/index.php?option=com_content&view=article&id=4&Itemid=6,Asia/Bishkek,IKU,KG,Cholpon-Ata,Ysyk-Koel,,AP
 ILA,WABL,Illaga,-3.65,133.73334,0,,Asia/Jayapura,ILA,ID,,,,AP
-ILB,,Ilha Solteira,-20.333332,-51.333332,1056,,America/Campo_Grande,ILB,BR,Ilha Solteira,Sao Paulo,Ilha Solteira,AP
 ILD,LEDA,Lleida-Alguaire Airport,41.72779095,0.5391262971137656,1122,http://www.aeroportlleida.cat/?L=2,Europe/Madrid,ILD,ES,Alguaire,Catalonia,Provincia de Lleida,AP
 ILE,KILE,Municipal,31.08639,-97.68667,836,http://www.skylarkfield.net/,America/Chicago,ILE,US,Harker Heights,Texas,Bell County,AP
 ILF,CZBD,Ilford,56.052567,-95.6137982,636,,America/Winnipeg,ILF,CA,,,,AP
@@ -3490,7 +3480,6 @@ INC,ZLIC,Yinchuan Hedong International Airport,38.3211525,106.38861654513931,376
 IND,KIND,Indianapolis International Airport,39.7162533,-86.29508388539975,797,http://www.indianapolisairport.com/,America/Indiana/Indianapolis,IND,US,Speedway,Indiana,Marion County,AP
 INE,,Chinde,-18.616667,36.4,42,,Africa/Maputo,INE,MZ,,,,AP
 INF,DATG,Newark Liberty International,19.616667,5.866667,1545,,Africa/Algiers,INF,DZ,,,,AP
-ING,,Lago Argentino,-50.583332,-72.666664,2506,,America/Argentina/Rio_Gallegos,ING,AR,El Calafate,Santa Cruz,,AP
 INH,FQIN,Inhambane Airport,-23.874443,35.408333,55,,Africa/Maputo,INH,MZ,Inhambane,Inhambane,,AP
 INI,LYNI,Nis Constantine the Great Airport,43.336109,21.85733488617226,613,,Europe/Belgrade,INI,RS,Nis,Central Serbia,Nisavski Okrug,AP
 INJ,YINJ,Injune,-25.8526452,148.5518976,1269,,Australia/Brisbane,INJ,AU,,,,AP
@@ -3515,7 +3504,6 @@ ION,FCOI,Impfondo,1.59018215,18.050921240957845,1010,,Africa/Brazzaville,ION,CG,
 IOP,,Ioma,-8.35,147.75,285,,Pacific/Port_Moresby,IOP,PG,,,,AP
 IOR,EIIM,Kilronan,53.11667,-9.75,0,,Europe/Dublin,IOR,IE,Clifden,Connaught,County Galway,AP
 IOS,SBIL,Ilheus/Bahia-Jorge Amado Airport,-14.813889,-39.03,13,,America/Bahia,IOS,BR,Ilheus,Bahia,Ilheus,AP
-IOU,,Ile Ouen,-22.463888,166.78305,0,,Pacific/Noumea,IOU,NC,Mont-Dore,South Province,Le Mont-Dore,AP
 IOW,KIOW,Iowa City,41.666668,-91.53333,718,http://www.icgov.org/?id=1501,America/Chicago,IOW,US,Iowa City,Iowa,Johnson County,AP
 IPA,NVVI,Ipota,-18.75,169.18333,446,,Pacific/Efate,IPA,VU,,,,AP
 IPC,SCIP,Mataveri International Airport,-27.116667,-109.36667,757,,Pacific/Easter,IPC,CL,Ostrov Paskhi,,,AP
@@ -3527,7 +3515,6 @@ IPL,KIPL,Imperial County Airport,32.83500895,-115.57428270065972,-82,,America/Lo
 IPN,SBIP,Usiminas Airport,-19.5,-42.533333,725,,America/Sao_Paulo,IPN,BR,Ipatinga,Minas Gerais,Ipatinga,AP
 IPT,KIPT,Lycoming County Airport,41.24135285,-76.91980562932577,515,,America/New_York,IPT,US,Montoursville,Pennsylvania,Lycoming County,AP
 IPU,SNIU,Ipiau,-14.133333,-39.733334,410,,America/Bahia,IPU,BR,Ipiau,Bahia,Ipiau,AP
-IPW,,Ipswich,52.066666,1.166667,147,,Europe/London,IPW,GB,Ipswich,England,Suffolk,AP
 IPZ,MRSI,San Isidro de El General Airport,9.348611,-83.7125,2486,,America/Costa_Rica,IPZ,CR,San Isidro,San Jose,,AP
 IQA,ORAA,Al Asad Air Base,63.75175,-68.53658,45,,Asia/Baghdad,IQA,IQ,,,,AP
 IQM,ZWCM,Qiemo Airport,38.14958345,85.53253116530601,4137,,Asia/Shanghai,IQM,CN,,,,AP
@@ -3556,7 +3543,6 @@ ISC,EGHE,St Marys,49.913334,-6.291667,82,http://www.scilly.gov.uk/transport/aira
 ISD,,Iscuande,2.4468635,-77.9813151,16,,America/Bogota,ISD,CO,Iscuande,Narino,,AP
 ISE,LTFC,Isparta Suleyman Demirel Airport,37.85602305,30.36730433725927,2847,http://www.dhmi.gov.tr/dosyalar/limanvemeydanlar/sdemirel/sdemirel.asp,Europe/Istanbul,ISE,TR,Keciborlu,Isparta,,AP
 ISG,ROIG,Painushima Ishigaki Airport,24.336945,124.16889,55,,Asia/Tokyo,ISG,JP,Ishigaki,Okinawa,,AP
-ISH,,Ischia Airport,40.733334,13.95,72,,Europe/Rome,ISH,IT,Ischia,Campania,Provincia di Napoli,AP
 ISI,YISF,Isisford,-24.2619884,144.4282046,652,,Australia/Brisbane,ISI,AU,,,,AP
 ISJ,MMIM,Isla Mujeres,21.24591925,-86.74047119765788,22,,America/Cancun,ISJ,MX,Isla Mujeres,Quintana Roo,,AP
 ISK,VAOZ,Gandhinagar Airport,19.966942,73.811264,1948,,Asia/Kolkata,ISK,IN,Deolali,Maharashtra,Nashik Division,AP
@@ -3585,7 +3571,6 @@ ITR,SBIT,Hidroeletrica,-18.44603765,-49.21306537143137,1538,,America/Sao_Paulo,I
 ITU,UHSI,Iturup,45.25471985,147.96086383247862,383,,Asia/Srednekolymsk,ITU,RU,Kuril'sk,Hokkaido,,AP
 IUE,NIUE,Hanan Airport,-19.0804765,-169.92138016169685,167,,Pacific/Niue,IUE,NU,Alofi,,,AP
 IUL,WABE,Ilu,-3.7065730500000003,138.20039368553904,6358,,Asia/Jayapura,IUL,ID,,,,AP
-IUM,,Summit Lake,54.333332,-122.666664,2319,,America/Vancouver,IUM,CA,,,,AP
 IUP,,Lorenzo Airport,-7.1726927603202,-59.8393706089647,616,,America/Manaus,IUP,BR,Apui,,,AP
 IUS,,Inus,-5.816667,155.16667,147,,Pacific/Port_Moresby,IUS,PG,,,,AP
 IVA,FMNZ,Ambanja,-13.6446652,48.4565628,45,,Indian/Antananarivo,IVA,MG,Ambanja,Diana,,AP
@@ -3639,12 +3624,10 @@ JAE,SPJE,Shumba Airport,33.638058,-84.424446,994,,America/New_York,CIX,PE,,,,AP
 JAF,VCCJ,Kankesanturai,9.792629949999998,80.0689781508496,39,,Asia/Colombo,JAF,LK,Valvedditturai,Northern Province,,AP
 JAG,OPJA,Jacobabad,28.28384345,68.45826131062442,177,,Asia/Karachi,JAG,PK,Jacobabad,Sindh,,AP
 JAI,VIJP,Jaipur Airport,26.8281087,75.8059454340161,1250,https://www.jaipurairport.com/,Asia/Kolkata,JAI,IN,Jaipur,Rajasthan,Jaipur,AP
-JAJ,,Perimeter Mall,33.635277,-84.42167,974,,America/New_York,ATL,US,Hapeville,Georgia,Fulton County,AP
 JAK,MTJA,Jacmel Regional Airport,18.240557,-72.51861,121,,America/Port-au-Prince,JAK,HT,Jacmel,Sud-Est,,AP
 JAL,MMJA,Jalapa,19.472221,-96.781944,3038,,America/Mexico_City,JAL,MX,Dos Rios,Veracruz,Emiliano Zapata,AP
 JAM,LBIA,Jambol,42.516666,26.483334,531,,Europe/Sofia,JAM,BG,Yambol,Yambol,Obshtina Yambol,AP
 JAN,KJAN,Jackson-Evers International Airport,32.312110399999995,-90.07677829423244,298,http://www.jmaa.com,America/Chicago,JAN,US,Flowood,Mississippi,Rankin County,AP
-JAO,,Beaver Ruin,33.64639,-84.43278,997,,America/New_York,ATL,US,College Park,Georgia,Fulton County,AP
 JAP,MRCH,Punta Renes,9.966667,-84.833336,0,,America/Costa_Rica,JAP,CR,Puntarenas,Puntarenas,Canton Central de Puntarenas,AP
 JAQ,AYJB,Jacquinot Bay,-5.6,151.51666,0,,Pacific/Port_Moresby,JAQ,PG,,,,AP
 JAR,OISJ,Jahrom,28.516666,53.55,3441,,Asia/Tehran,JAR,IR,Jahrom,Fars,,AP
@@ -3655,24 +3638,16 @@ JAV,BGJN,Ilulissat Airport,69.24366964999999,-51.056119024204875,49,,America/God
 JAW,SNAB,Aeroporto de Araripina,-7.586389,-40.535556,2195,,America/Recife,JAW,BR,,,,AP
 JAX,KJAX,Jacksonville International Airport,30.4947303,-81.6924513519536,19,http://www.jaa.aero/,America/New_York,JAX,US,Nassau Village-Ratliff,Florida,Nassau County,AP
 JBB,WARE,Notohadinegoro Airport,-8.2421527,113.69370831834904,223,,Asia/Jakarta,JBB,ID,Renes,East Java,,AP
-JBC,,Boston City Heliport,42.343887,-71.049446,29,,America/New_York,BOS,US,South Boston,Massachusetts,Suffolk County,AP
 JBK,,Berkeley,37.86667,-122.3,36,,America/Los_Angeles,JBK,US,Albany,California,Alameda County,AP
 JBQ,MDJB,La Isabela International Airport,18.5713644,-69.98602447318345,85,,America/Santo_Domingo,SDQ,DO,Santo Domingo,Nacional,,AP
 JBR,KJBR,Jonesboro Airport,35.83,-90.64833,229,,America/Chicago,JBR,US,Jonesboro,Arkansas,Craighead County,AP
 JBS,SSSB,Hacienda Bus.Park Heliport,37.699722,-121.9,360,,America/Los_Angeles,JBS,US,Dublin,California,Alameda County,AP
 JBT,Z59,City Landing,60.8,-161.75,36,,America/Anchorage,BET,US,,,,AP
 JCB,SSJA,Joacaba,-27.17148265,-51.55345654971351,2516,,America/Sao_Paulo,JCB,BR,Joacaba,Santa Catarina,Joacaba,AP
-JCC,,China Basin Heliport,37.75,-122.416664,104,,America/Los_Angeles,SFO,US,San Francisco,California,San Francisco County,AP
-JCD,,Downtown Heliport,17.7,-64.78333,36,,America/St_Thomas,STX,VI,,,,AP
-JCE,,Convention Center Heliport,37.816666,-122.26667,85,,America/Los_Angeles,OAK,US,Oakland,California,Alameda County,AP
-JCH,,Qasigiannguit,68.81515,-51.20133,0,,America/Godthab,JCH,GL,,,,AP
 JCI,KIXD,New Century Aircenter Airport,38.833332,-94.9,1118,,America/Chicago,MKC,US,Gardner,Kansas,Johnson County,AP
-JCJ,,Chuja Heliport,33.944443,126.32778,0,,Asia/Seoul,CJU,KR,,,,AP
 JCK,YJLC,Julia Creek,-20.583332,141.7,387,,Australia/Brisbane,JCK,AU,,,,AP
 JCL,LKCS,České Budějovice Airport,48.946389,14.428056,432,,Europe/Prague,JCL,CZ,,,,AP
 JCM,SNJB,Jacobina,-11.1640584,-40.55150285692899,1548,,America/Bahia,JCM,BR,Jacobina,Bahia,Jacobina,AP
-JCN,,Incheon Heliport,37.466667,126.6,16,,Asia/Seoul,JCN,KR,Incheon,Incheon,,AP
-JCO,,Heliport,36.016666,14.333333,42,,Europe/Malta,JCO,MT,Qala,Il-Qala,,AP
 JCR,SBEK,Jacareacanga,-5.983333,-57.533333,557,,America/Santarem,JCR,BR,,,,AP
 JCS,SNWS,Aeroporto De Crateus Airport,-5.21230869969,-40.7045819389,1026,http://www.crateus.ce.gov.br/,America/Fortaleza,JCS,BR,Crateus,,,AP
 JCT,KJCT,Kimble County,30.510357550000002,-99.76556102069245,1666,,America/Chicago,JCT,US,Junction,Texas,Kimble County,AP

--- a/airports.csv
+++ b/airports.csv
@@ -380,7 +380,7 @@ ART,KART,Watertown Airport,43.990833,-76.021385,275,,America/New_York,ART,US,Dex
 ARU,SBAU,Aracatuba Airport,-21.140815,-50.425139094792286,1341,http://www.daesp.sp.gov.br/aeroporto-estadual-de-aracatuba-dario-guarita/,America/Sao_Paulo,ARU,BR,Aracatuba,Sao Paulo,Aracatuba,AP
 ARV,KARV,Noble F. Lee,45.924168,-89.73222,1614,,America/Chicago,ARV,US,Lac du Flambeau,Wisconsin,Vilas County,AP
 ARW,LRAR,Arad,46.183334,21.266666,357,,Europe/Bucharest,ARW,RO,Arad,Arad,,AP
-ARX,SBAC,Asbury Park,40.216667,-74.1,88,,America/New_York,ARX,US,Shark River Hills,New Jersey,Monmouth County,AP
+ARX,SBAC,Canoa Quebrada Dragão do Mar Regional Airport,-4.568611,-37.804722,115,,America/Fortaleza,ARX,BR,,,,AP
 ARY,YARA,Ararat,-37.31213875,142.9942951850989,1010,,Australia/Melbourne,ARY,AU,Ararat,Victoria,Ararat,AP
 ARZ,FNZE,N'zeto,-7.5,13.5,846,,Africa/Luanda,ARZ,AO,,,,AP
 ASA,HHSB,Assab International,13.07595515,42.641747301941436,32,,Africa/Asmara,ASA,ER,,,,AP
@@ -571,7 +571,7 @@ BBH,EDBH,Barth,54.33965175,12.712626338183224,26,,Europe/Berlin,BBH,DE,,,,AP
 BBI,VEBS,Biju Patnaik International Airport,20.25229545,85.81348472447162,121,http://aai.aero/allAirports/bhubaneshwar_generalinfo.jsp,Asia/Kolkata,BBI,IN,Bhubaneshwar,Odisha,Khordha,AP
 BBJ,EDRB,Bitburg Air Base,49.946165,6.565966668652097,1220,,Europe/Berlin,BBJ,DE,Bitburg,Rheinland-Pfalz,,AP
 BBK,FBKE,Kasane Airport,-17.83045705,25.164367059707985,3277,,Africa/Gaborone,BBK,BW,Kasane,North West,,AP
-BBL,YLLE,Ballera Airport,27.408333,141.808333,385,,Australia/Brisbane,BBL,AU,,,,AP
+BBL,YLLE,Ballera Airport,-27.408333,141.808333,385,,Australia/Brisbane,BBL,AU,,,,AP
 BBM,VDBG,Battambang,13.0956576,103.22694944923883,45,,Asia/Phnom_Penh,BBM,KH,Battambang,Battambang,,AP
 BBN,WBGZ,Bario Airport,3.683333,115.46667,3497,,Asia/Kuching,BBN,MY,,,,AP
 BBO,HCMI,Berbera,10.419444,45.00639,59,,Africa/Mogadishu,BBO,SO,Berbera,Woqooyi Galbeed,,AP
@@ -917,7 +917,7 @@ BOW,KBOW,Bartow,27.9,-81.833336,72,http://www.bartow-airport.com/,America/New_Yo
 BOX,YBRL,Borroloola,-16.07668335,136.3031001483854,52,,Australia/Darwin,BOX,AU,,,,AP
 BOY,DFOO,Borgo,11.163611,-4.324444,1519,,Africa/Ouagadougou,BOY,BF,Bobo-Dioulasso,High-Basins,Province du Houet,AP
 BOZ,FEGZ,Bozoum,6.416667,16.583332,2171,,Africa/Bangui,BOZ,CF,Bozoum,Ouham-Pende,,AP
-BPA,,Grumman,40.733334,-73.48333,111,,America/New_York,BPA,US,Bethpage,New York,Nassau County,AP
+BPA,RPVW,Borongan Airport,11.674167,125.467778,19,,Asia/Manila,BPA,PH,,,,AP
 BPB,,Boridi,-9.133333,147.53334,3238,,Pacific/Port_Moresby,BPB,PG,,,,AP
 BPC,FKKV,Bamenda,5.916667,10.15,4478,,Africa/Douala,BPC,CM,Bamenda,North-West Province,,AP
 BPD,AYBP,Bapi,-7.7435241999999995,147.02076956345297,2906,,Pacific/Port_Moresby,BPD,PG,,,,AP
@@ -1272,7 +1272,7 @@ CEG,EGNR,Hawarden Airport,53.1796073,-2.9728660097029813,36,,Europe/London,CEG,G
 CEH,FWCD,Chelinda,-10.5575399,33.7979301,7726,,Africa/Blantyre,CEH,MW,Livingstonia,Northern Region,Rumphi District,AP
 CEI,VTCT,Chiang Rai International Airport,19.9480922,99.87945678537508,1368,,Asia/Bangkok,CEI,TH,Chiang Rai,Chiang Rai,,AP
 CEK,USCC,Chelyabinsk International Airport,55.3015326,61.5128637881277,721,http://cekport.ru/,Asia/Yekaterinburg,CEK,RU,Potanino,Chelyabinsk,,AP
-CEL,,Cape Eleuthera,25.28389,-76.33083,62,,America/Nassau,CEL,BS,,,,AP
+CEL,SSCN,Canela Airport,-29.370556,-50.832222,2713,,America/Sao_Paulo,CEL,BR,,,,AP
 CEM,PACE,Central,65.5736598,-144.7779019786591,885,,America/Anchorage,CEM,US,,,,AP
 CEN,MMCN,Ciudad Obregon Airport,27.39138415,-109.83122548553126,157,http://obregon.asa.gob.mx/wb/webasa/obregon_aeropuertos,America/Hermosillo,CEN,MX,Antonio Rosales,Sonora,Cajeme,AP
 CEO,FNWK,Waco Kungo,9.308333,124.73055,0,,Africa/Luanda,CEO,AO,Mambajao,Northern Mindanao,Province of Camiguin,AP
@@ -2022,6 +2022,7 @@ DXB,OMDB,Dubai Airport,25.248665,55.352917,39,http://www.dubaiairport.com/dia/en
 DXD,YDIX,Dixie,-15.166667,143.66667,574,,Australia/Brisbane,DXD,AU,,,,AP
 DXE,KMBO,Bruce Campbell Field,32.4392835,-90.10313414239927,246,http://www.madisonthecity.com/airport,America/Chicago,DXE,US,Madison,Mississippi,Madison County,AP
 DXJ,ZGXX,Xiangxi Biancheng Airport,28.4972,109.5218,2299,,Asia/Shanghai,DXJ,CN,,,Hunan,AP
+DXN,VIND,Noida International Airport,28.179868,77.611843,644,https://www.niairport.in,Asia/Kolkata,DXN,IN,Jewar,Uttar Pradesh,Gautam Buddha Nagar,AP
 DXR,KDXR,Danbury Municipal Airport,41.3721531,-73.48139626519684,433,,America/New_York,DXR,US,Danbury,Connecticut,Fairfield County,AP
 DYA,YDYS,Dysart,-23.5,148.0,672,,Australia/Brisbane,DYA,AU,,,,AP
 DYG,ZGDY,Zhangjiajie Hehua Airport,29.103868499999997,110.44472066563625,679,,Asia/Shanghai,DYG,CN,,,,AP
@@ -2543,7 +2544,7 @@ GBE,FBSK,Sir Seretse Khama International Airport,-24.5533921,25.924967923222077,
 GBF,AYNE,Negarbo,-6.56774825,144.7040875277135,4491,,Pacific/Port_Moresby,GBF,PG,,,,AP
 GBG,KGBG,Galesburg,40.9361974,-90.42724880295705,731,http://www.ci.galesburg.il.us/services/airport/,America/Chicago,GBG,US,Galesburg,Illinois,Knox County,AP
 GBH,PAGB,Galbraith Lake,68.4788889,-149.49,2634,,America/Anchorage,GBH,US,,,,AP
-GBI,MYGM,Auxiliary Airfield,26.666668,-78.5,22,,America/Nassau,GBI,BS,Lucaya,Freeport,,AP
+GBI,VOGB,Kalaburagi Airport,17.307778,76.958056,1571,,Asia/Kolkata,GBI,IN,,,,AP
 GBJ,TFFM,Les Bases,15.866667,-61.266666,0,,America/Guadeloupe,GBJ,GP,Grand-Bourg,Guadeloupe,Guadeloupe,AP
 GBK,GFGK,Gbangbatok,7.81271795,-12.377632906257602,167,,Africa/Freetown,GBK,SL,Mogbwemo,Southern Province,,AP
 GBL,YGBI,Goulburn Island,-11.55,133.43333,0,,Australia/Darwin,GBL,AU,,,,AP
@@ -3628,7 +3629,7 @@ JSI,LGSK,Skiathos Airport,39.17848895,23.50318526783782,54,,Europe/Athens,JSI,GR
 JSJ,ZYJS,Jiansanjiang Shidi Airport,47.1066465,132.6632288591807,0,,Asia/Shanghai,JSJ,CN,Fujin,Heilongjiang Sheng,,AP
 JSK,OIZJ,Jask Airport,25.65476,57.80172,29,,Asia/Tehran,JSK,IR,Jask,Hormozgan,,AP
 JSM,SAWS,Jose De San Martin,-44.04784775,-70.44501939480728,2407,,America/Argentina/Catamarca,JSM,AR,Jose de San Martin,Chubut,,AP
-JSO,,Sodertalje Heliport,59.2,17.65,0,,Europe/Stockholm,JSO,SE,,,,AP
+JSO,SN6L,Sobral Regional Airport,-3.614722,-40.232222,299,,America/Fortaleza,JSO,BR,Sobral,,,AP
 JSR,VGJR,Jessore Airport,23.1831797,89.1611447,20,,Asia/Dhaka,JSR,BD,Jessore,Khulna,,AP
 JST,KJST,Cambria County Airport,40.31459165,-78.83353249226279,2284,,America/New_York,JST,US,Geistown,Pennsylvania,Cambria County,AP
 JSU,BGMQ,Heliport,65.416664,-52.9,91,,America/Godthab,JSU,GL,Maniitsoq,Qeqqata,,AP
@@ -3781,7 +3782,7 @@ KEQ,WASE,Kebar,-5.833333,134.83333,2050,,Asia/Jayapura,KEQ,ID,Dobo,Maluku,,AP
 KER,OIKK,Kerman Airport,30.258778,56.96192,5741,,Asia/Tehran,KER,IR,Kerman,Kerman,,AP
 KES,CZEE,Kelsey,56.0377456,-96.5107075,600,,America/Winnipeg,KES,CA,,,,AP
 KET,VYKG,Keng Tung Airport,21.3,99.61667,2798,,Asia/Rangoon,KET,MM,,,,AP
-KEU,HKKE,Kelly Bar,67.916664,-162.28334,5800,,America/Nome,KEU,US,,,,AP
+KEU,HKKE,Keekorok Airport,-1.585833,35.251667,5800,,Africa/Nairobi,KEU,KE,,,,AP
 KEV,EFHA,Halli,61.583332,24.75,479,,Europe/Helsinki,KEV,FI,Kuhmalahti,Pirkanmaa,Tampere,AP
 KEW,CPV8,Keewaywin,52.99062345,-92.83464187322227,988,,America/Winnipeg,KEW,CA,,,,AP
 KEX,AYNB,Kanabea,-7.483333,145.91667,4288,,Pacific/Port_Moresby,KEX,PG,,,,AP
@@ -6405,6 +6406,7 @@ PXA,WIPY,Atung Bungsu Airport,-4.0225,103.379167,2020,,Asia/Jakarta,PXA,ID,Kotaa
 PXH,YPMH,Prominent Hill,-29.7101355,135.52772941953702,692,,Australia/Adelaide,PXH,AU,,,,AP
 PXL,P10,Polacca,35.8,-110.333336,5823,,America/Phoenix,PXL,US,First Mesa,Arizona,Navajo County,AP
 PXM,MMPS,Puerto Escondido Airport,15.85,-97.083336,0,,America/Mexico_City,PXM,MX,Puerto Escondido,Oaxaca,San Pedro Mixtepec -Dto. 22 -,AP
+PXN,VEPU,Purnea Airport,25.7596,87.41000366,129,,Asia/Kolkata,PXN,IN,Purnia,Bihar,,AP
 PXO,LPPS,Porto Santo Airport,33.07362365,-16.34816497905559,252,http://www.anam.pt/Porto-Santo-411.aspx,Atlantic/Madeira,PXO,PT,Vila de Porto Santo,Madeira,Porto Santo,AP
 PXR,VTUJ,Surin,14.86680565,103.4979606001036,331,,Asia/Bangkok,PXR,TH,Surin,Surin,,AP
 PXU,VVPK,Pleiku Airport,14.004424,108.0135475589313,2411,,Asia/Ho_Chi_Minh,PXU,VN,Pleiku,Gia Lai,,AP
@@ -6915,7 +6917,7 @@ SEP,KSEP,Clark Field,32.216667,-98.2,1256,http://www.stephenvilletx.gov/city-ser
 SEQ,WIBS,Sungai Pakning,-0.8,114.066666,249,,Asia/Jakarta,SEQ,ID,Buntok,Central Kalimantan,,AP
 SER,KSER,Freeman Municipalcipal,38.966667,-85.88333,626,http://seymourcity.com/departments/aviation/,America/Indiana/Indianapolis,SER,US,Seymour,Indiana,Jackson County,AP
 SES,,Selfield,32.726112,-87.08722,291,,America/Chicago,SES,US,Centreville,Alabama,Bibb County,AP
-SET,,San Esteban,15.316667,-85.86667,2910,,America/Tegucigalpa,SET,HN,San Esteban,Olancho,,AP
+SET,SNHS,Serra Talhada Airport,-8.061389,-38.328611,1542,,America/Recife,SET,BR,,,,AP
 SEU,HTSN,Seronera Airstrip,-2.383333,34.816666,4730,,Africa/Dar_es_Salaam,SEU,TZ,Mugumu,Mara,,AP
 SEV,UKCS,Severodoneck,48.90159785,38.54204574366283,193,,Europe/Kiev,SEV,UA,Syevyerodonets'k,Luhansk,,AP
 SEW,HE24,Siwa,29.183332,25.516666,-36,,Africa/Cairo,SEW,EG,Siwa Oasis,Muhafazat Matruh,,AP
@@ -7114,7 +7116,7 @@ SMP,,Stockholm,-4.566667,151.96666,1978,,Pacific/Port_Moresby,SMP,PG,,,,AP
 SMQ,WAGS,H. Asan Airport,-3.083333,113.05,0,,Asia/Pontianak,SMQ,ID,Semuda,Central Kalimantan,,AP
 SMR,SKSM,Simon Bolivar International Airport,11.117132,-74.232704,39,,America/Bogota,SMR,CO,Cienaga,Magdalena,,AP
 SMS,FMMS,Sainte Marie,-17.093889,49.815833,7,,Indian/Antananarivo,SMS,MG,Ambodifotatra,Analanjirofo,,AP
-SMT,SBSO,Sun Moon Lake,23.883333,120.933334,2355,,Asia/Taipei,SMT,TW,Puli,Taiwan,Nantou,AP
+SMT,SBSO,Sorriso Airport,-12.472778,-55.668889,1266,,America/Cuiaba,SMT,BR,,,,AP
 SMU,PASP,Sheep Mountain,61.8,-147.66667,1945,,America/Anchorage,SMU,US,Sutton-Alpine,Alaska,Matanuska-Susitna Borough,AP
 SMV,LSZS,Samedan,46.5340996,9.8841105,5577,,Europe/Zurich,SMV,CH,Samedan,Grisons,Maloja District,AP
 SMW,GMMA,Smara,26.732671699999997,-11.684303688564786,574,,Africa/Casablanca,SMW,MA,Smara,,,AP
@@ -8046,7 +8048,7 @@ ULX,FAUS,Ulusaba,-24.7814137,31.3555238,1263,,Africa/Johannesburg,ULX,ZA,Thulama
 ULY,UWLW,Ulyanovsk Vostochny Airport,54.266666,48.216667,252,,Europe/Samara,ULY,RU,Isheyevka,Ulyanovsk,,AP
 ULZ,ZMDN,Uliastai,47.7414683,96.8499229,5800,,Asia/Hovd,ULZ,MN,Uliastay,Dzabkhan,,AP
 UMA,MUMA,Punta De Maisi,20.2423436,-74.1490094,3,,America/Havana,UMA,CU,Maisi,Guantanamo,,AP
-UMB,,North Shore,53.376667,-167.8875,0,,America/Anchorage,UMB,US,,,,AP
+UMB,FLKM,Kalumbila Airport,-12.2536,25.4443,4354,,Africa/Lusaka,UMB,ZM,,,,AP
 UMC,AYUC,Umba,-7.021325,145.96630039886003,5950,,Pacific/Port_Moresby,UMC,PG,,,,AP
 UME,ESNU,Umea Airport,63.7903095,20.288655093670805,24,https://www.swedavia.com/umea/,Europe/Stockholm,UME,SE,Umea,Vaesterbotten,Umea Kommun,AP
 UMI,SPIL,Quincemil,-13.25,-70.666664,2047,,America/Lima,UMI,PE,Quince Mil,Cusco,Provincia de Quispicanchis,AP
@@ -9161,7 +9163,7 @@ ZEN,AYZA,Zenag,-6.95,146.61667,3200,,Pacific/Port_Moresby,ZEN,PG,Bulolo,Morobe,B
 ZER,VEZO,Zero,27.633333,93.833336,5403,,Asia/Kolkata,ZER,IN,Ziro,Arunachal Pradesh,Lower Subansiri,AP
 ZFA,CZFA,Faro,63.216667,-133.36667,2351,,America/Whitehorse,ZFA,CA,Whitehorse,Yukon,,AP
 ZFD,CZFD,Fond-du-Lac Airport,59.3344002,-107.1819992,814,,America/Regina,ZFD,CA,Fond du Lac,Saskatchewan,,AP
-ZFL,,South Trout Lake,50.833332,-93.65,0,,America/Winnipeg,ZFL,CA,,,,AP
+ZFL,,Zhaosu Tianma Airport,43.1075,81.160556,5830,,Asia/Urumqi,ZFL,CN,,,,AP
 ZFM,CZFM,Fort Mcpherson,67.477776,-134.95277,116,,America/Yellowknife,ZFM,CA,Fort McPherson,Northwest Territories,,AP
 ZFN,CZFN,Tulita,64.90878649999999,-125.56970777368883,332,,America/Yellowknife,ZFN,CA,Norman Wells,Northwest Territories,,AP
 ZFW,CEB5,Fairview,56.066666,-118.38333,2166,,America/Edmonton,ZFW,CA,Fairview,Alberta,,AP

--- a/airports.csv
+++ b/airports.csv
@@ -186,7 +186,7 @@ AIL,,Ailigandi,9.25,-78.083336,55,,America/Panama,AIL,PA,Ailigandi,Guna Yala,,AP
 AIM,,Ailuk Island,10.2164987,169.9825736,45,,Pacific/Majuro,AIM,MH,,,,AP
 AIN,PAWI,Wainwright,70.63790295000001,-160.0150279490063,22,,America/Anchorage,AIN,US,,,,AP
 AIO,KAIO,Municipal,41.4,-95.01667,1250,,America/Chicago,AIO,US,Atlantic,Iowa,Cass County,AP
-AIP,VIAX,Ailinglapalap Island,7.266667,168.81667,0,,Pacific/Majuro,AIP,MH,,,,AP
+AIP,VIAX,Sri Guru Ravidas Airport,31.433056,75.760556,776,,Asia/Kolkata,AIP,IN,Adampur,Punjab,Jalandhar,AP
 AIR,SSOU,Aripuana,-10.25,-59.38333,1095,,America/Cuiaba,AIR,BR,,,,AP
 AIS,NGTR,Arorae Island,-2.65,176.83333,45,,Pacific/Tarawa,AIS,KI,Kulia Village,Niutao,,AP
 AIT,NCAI,Aitutaki Airport,-18.8364468,-159.76131004763312,78,,Pacific/Rarotonga,AIT,CK,,,,AP
@@ -1244,7 +1244,7 @@ CDA,YCOO,Cooinda,-12.90328085,132.53301052481424,32,,Australia/Darwin,CDA,AU,,,,
 CDB,PACD,Cold Bay Airport,55.2014611,-162.7198441,55,,America/Nome,CDB,US,,,,AP
 CDC,KCDC,Cedar City Airport,37.7003,-113.0986,5636,,America/Denver,CDC,US,Cedar City,Utah,Iron County,AP
 CDD,MHCU,Cauquira,15.32120995,-83.60406201630377,22,,America/Tegucigalpa,CDD,HN,,,,AP
-CDE,ZBCD,Caledonia,8.333333,-77.55,351,,America/Panama,CDE,PA,Corozal,Embera,,AP
+CDE,ZBCD,Chengde Puning Airport,41.1225,118.073889,2297,,Asia/Shanghai,CDE,CN,,,,AP
 CDG,LFPG,Charles de Gaulle Airport,49.0068908,2.5710819691019156,337,http://www.aeroportsdeparis.fr/,Europe/Paris,PAR,FR,,,,AP
 CDH,KCDH,Harrell Field,33.583332,-92.833336,170,,America/Chicago,CDH,US,Camden,Arkansas,Ouachita County,AP
 CDI,SNKI,Cachoeiro Itapemirim,-20.834752,-41.185587839495895,219,,America/Sao_Paulo,CDI,BR,Cachoeiro de Itapemirim,Espirito Santo,Cachoeiro De Itapemirim,AP
@@ -1541,7 +1541,7 @@ CQM,LERL,Ciudad Real Central,38.983334,-3.916667,2093,http://www.aeropuertocentr
 CQP,YCFL,Cape Flattery,-18.2,147.5,3609,,Australia/Brisbane,CQP,AU,Magnetic Island,Queensland,Townsville,AP
 CQS,SWCQ,Costa Marques,-12.4249231,-64.25192287574623,456,,America/Porto_Velho,CQS,BR,,,,AP
 CQT,,Caquetania,1.616667,-74.166664,807,,America/Bogota,CQT,CO,,,,AP
-CQW,,CHERAW MUNI/LYNCH BELLINGER FLD AIRPORT,34.7129,-79.957,209,,America/New_York,CQW,US,,,,AP
+CQW,ZUWL,Chongqing Xiannvshan Airport,29.465833,107.692222,5730,,Asia/Shanghai,CQW,CN,Xiannyushan,Chongqing,,AP
 CRA,LRCV,Craiova Airport,44.318807050000004,23.889104852848654,603,http://www.aeroportcraiova.ro/,Europe/Bucharest,CRA,RO,Carcea,Dolj,Comuna Carcea,AP
 CRB,YCBR,Collarenebri,-29.524299,148.5768224,462,,Australia/Sydney,CRB,AU,,,,AP
 CRC,SKGO,Cartago,4.766667,-75.933334,2972,,America/Bogota,CRC,CO,Cartago,Valle del Cauca,,AP
@@ -2977,7 +2977,7 @@ HGA,HCMH,Hargeisa Airport,9.512619050000001,44.079853877194694,4461,http://l.fac
 HGD,YHUG,Hughenden,-20.816494,144.2268828,1003,,Australia/Brisbane,HGD,AU,,,,AP
 HGE,SVHG,Higuerote Airport,10.46339655,-66.09609106977287,26,,America/Caracas,HGE,VE,Higuerote,Miranda,Municipio Brion,AP
 HGH,ZSHC,Hangzhou Xiaoshan International Airport,30.2368729,120.42912444938366,26,http://www.hzairport.com/,Asia/Shanghai,HGH,CN,,,,AP
-HGI,,Higlieg,10.98333333,32.0,1279,,Africa/Khartoum,HGI,SD,Abu Jibeha,Southern Kordofan,,AP
+HGI,VEHO,Hollongi Airport,26.97,93.664722,328,,Asia/Kolkata,HGI,IN,Hollongi,Arunachal Pradesh,,AP
 HGL,EDXH,Helgoland,54.18553595,7.9143290146581595,26,http://www.flughafen-helgoland.de,Europe/Berlin,HGL,DE,Helgoland,Schleswig-Holstein,,AP
 HGN,VTCH,Mae Hong Son Airport,19.3010716,97.97606956686425,875,,Asia/Bangkok,HGN,TH,Mae Hong Son,Mae Hong Son,,AP
 HGO,DIKO,Korhogo Airport,9.413889,-5.616667,1236,,Africa/Abidjan,HGO,CI,Korhogo,Savanes,,AP
@@ -3052,7 +3052,7 @@ HMJ,UKLH,Khmelnitskiy,49.416668,27.0,954,,Europe/Kiev,HMJ,UA,Khmel'nyts'kyy,Khme
 HMN,KHMN,Holloman AFB,32.9,-105.95,4386,http://www.holloman.af.mil/,America/Denver,ALM,US,Alamogordo,New Mexico,Otero County,AP
 HMO,MMHO,Gen Pesqueira Garcia Airport,29.09210995,-111.05463682353957,616,,America/Hermosillo,HMO,MX,Hermosillo,Sonora,,AP
 HMR,ENHA,Hamar Airport,60.81817005,11.067417618542727,679,,Europe/Oslo,HMR,NO,Hamar,Hedmark,Hamar,AP
-HMS,,Homeshore,58.294445,-135.34723,433,,America/Juneau,HMS,US,,,,AP
+HMS,,Haji Muhammad Sidik Airport,-1.024722,114.927778,82,,Asia/Pontianak,HMS,ID,,,,AP
 HMT,KHMT,Ryan Field,33.733334,-117.025,1479,http://www.rchmtra.com/,America/Los_Angeles,HMT,US,Green Acres,California,Riverside County,AP
 HMV,ESUT,Hemavan Airport,65.727776,15.273056,2578,,Europe/Stockholm,HMV,SE,,,,AP
 HMY,RKTP,Seosan Airport,36.703999,126.486,55,,Asia/Seoul,HMY,KR,Suisan,Chungcheongnam-do,,AP
@@ -3203,7 +3203,7 @@ HYN,ZSLQ,Luqiao Airport,28.562648799999998,121.4248379160332,32,,Asia/Shanghai,H
 HYR,KHYR,Municipal,46.024445,-91.44444,1197,http://sawyercountygov.org/Departments/Airport/tabid/93/Default.aspx,America/Chicago,HYR,US,Hayward,Wisconsin,Sawyer County,AP
 HYS,KHYS,Hays Municipal Airport,38.84611,-99.27417,1965,,America/Chicago,HYS,US,Hays,Kansas,Ellis County,AP
 HYV,EFHV,Hyvinkaa,60.6531076,24.8818934,410,,Europe/Helsinki,HYV,FI,Hyvinge,Uusimaa,Helsinki,AP
-HZA,,Establecimiento El Araza Airport,-36.7756,-57.6414,26,,America/Argentina/Buenos_Aires,HZA,AR,General Guido,Buenos Aires,Partido de General Guido,AP
+HZA,ZSHZ,Heze Mudan Airport,35.213333,115.736667,151,,Asia/Shanghai,HZA,CN,Heze,Shandong,,AP
 HZB,LFQT,Merville/Calonne,50.61904975,2.6440712081169275,39,,Europe/Paris,HZB,FR,Merville,Nord-Pas-de-Calais,Departement du Nord,AP
 HZG,ZLHZ,Hanzhong Airport,32.983334,107.183334,1843,,Asia/Shanghai,HZG,CN,Xiangshui,Shaanxi,,AP
 HZH,ZUNP,Liping Airport,26.32249205,109.15044436646232,1617,,Asia/Shanghai,HZH,CN,Longlisuo,Guizhou Sheng,,AP
@@ -3559,7 +3559,7 @@ JIK,LGIK,Ikaria Airport,37.6829412,26.346215400974874,65,,Europe/Athens,JIK,GR,A
 JIL,ZYJL,Jilin,43.86667,126.65,859,,Asia/Shanghai,JIL,CN,Jilin,Jilin Sheng,,AP
 JIM,HAJM,Jimma Airport,7.6614832,36.82030042171516,5583,,Africa/Addis_Ababa,JIM,ET,Jima,Oromiya,,AP
 JIN,HUJI,Jinja,0.456389,33.192223,3802,,Africa/Kampala,JIN,UG,Jinja,Eastern Region,Jinja District,AP
-JIO,,International Heliport,34.066666,-117.65,994,,America/Los_Angeles,ONT,US,Ontario,California,San Bernardino County,AP
+JIO,WAPM,Jos Orno Imsula Airport,-8.140556,127.907222,13,https://hubud.kemenhub.go.id/upbu/jos-orno-imsula,America/Los_Angeles,ONT,ID,Tiakur,Maluku,,AP
 JIP,SEJI,Jipijapa,-1.0,-80.666664,239,,America/Guayaquil,JIP,EC,Montecristi,Manabi,,AP
 JIQ,ZUQJ,Qianjiang Wulingshan Airport,29.5152164,108.83089524946274,2073,,Asia/Shanghai,JIQ,CN,Zhoubai,Chongqing Shi,,AP
 JIR,VNJI,Jiri,27.6258495,86.2306576,5944,,Asia/Kathmandu,JIR,NP,,,,AP
@@ -3762,7 +3762,7 @@ KDW,,Vic. Resevour Kandy,7.3,80.63333,1402,,Asia/Colombo,KDW,LK,,,,AP
 KDX,HSLI,Kadugli,11.1379995,29.7010994,1848,,Africa/Khartoum,KDX,SD,Kadugli,Southern Kordofan,,AP
 KDY,UEMH,Mahaweli,7.466667,80.51667,925,,Asia/Colombo,KDY,LK,Kurunegala,North Western,,AP
 KDZ,,Polgolla Reservoir Airport,7.330555,80.64167,1473,,Asia/Colombo,KDZ,LK,Kandy,Central,,AP
-KEA,,Keisah Airport,-7.6667,140.5,141,,Asia/Jayapura,KEA,ID,,,,AP
+KEA,UTAE,Kerki International Airport,37.823333,65.14,770,http://www.tia.gov.tm/kerki/,Asia/Ashgabat,KEA,TM,Kerki,Lebap,,AP
 KEB,KEB,Nanwalek,59.35235445,-151.92467201361427,27,,America/Anchorage,KEB,US,,,,AP
 KEC,FZQG,Kasenga,-10.333333,28.75,3146,,Africa/Lubumbashi,KEC,CD,Mwense,Luapula,,AP
 KED,GQNK,Kaedi,16.16018205,-13.506780293555911,75,,Africa/Nouakchott,KED,MR,Kaedi,Gorgol,,AP
@@ -4382,7 +4382,7 @@ LKD,YLND,Lakeland Downs,-15.816667,144.95,930,,Australia/Brisbane,LKD,AU,,,,AP
 LKE,W55,Kenmore Air Harbor SPB,47.6275,-122.331665,14,http://www.kenmoreair.com/flight-information/terminals/seattle-terminals/seattle-lake-union-seaplane-terminal/,America/Los_Angeles,SEA,US,Seattle,Washington,King County,AP
 LKG,HKLK,Lokichoggio,4.203761350000001,34.34841238716451,2074,http://www.kenyaairports.co.ke/kaa/airports/loki/,Africa/Nairobi,LKG,KE,Kaabong,Northern Region,Kaabong District,AP
 LKH,WBGL,Long Akah,3.3110571999999996,114.78568113463946,289,,Asia/Kuching,LKH,MY,Long Ampan Aing or Abanang,Sarawak,,AP
-LKI,,Lakeside USAF,46.783333,-92.1,0,,America/Chicago,DLH,US,Duluth,Minnesota,Saint Louis County,AP
+LKI,WITG,Lasikin Airport,2.416667,96.329167,26,,Asia/Jakarta,DLH,ID,,,,AP
 LKK,PAKL,Kulik Lake,59.816666,-158.83333,717,,America/Anchorage,LKK,US,,,,AP
 LKL,ENNA,Banak Airport,70.06704400000001,24.96706388175396,25,https://avinor.no/en/airport/lakselv-airport/,Europe/Oslo,LKL,NO,Lakselv,Finnmark Fylke,Porsanger,AP
 LKM,,Raja Loloda Mokoagow Airport,-0.960556,122.111944,32,,Asia/Makassar,LKM,ID,,,,AP
@@ -6287,7 +6287,7 @@ PRC,KPRC,Prescott Airport,34.65,-112.424164,5022,,America/Phoenix,PRC,US,Chino V
 PRD,YPDO,Pardoo,-20.1,119.11667,26,,Australia/Perth,PRD,AU,,,,AP
 PRE,,Pore,5.733333,-71.983333,902,,America/Bogota,PRE,CO,,,,AP
 PRG,LKPR,Vaclav Havel Airport Prague,50.1020451,14.27056489323675,1181,http://www.prg.aero,Europe/Prague,PRG,CZ,Hostivice,Central Bohemia,,AP
-PRH,VTCP,Phrae Airport,18.13174175,100.16354112141005,515,,Asia/Bangkok,PRH,TH,Phrae,Phrae,,AP
+PRH,VTCP,Phrae Airport,18.131667,100.164444,538,,Asia/Bangkok,PRH,TH,Phrae,Phrae,,AP
 PRI,FSPP,Praslin Island Airport,-4.3186006500000005,55.691294938853574,55,,Indian/Mahe,PRI,SC,Victoria,English River,,AP
 PRK,FAPK,Prieska,-29.666668,22.7,3238,,Africa/Johannesburg,PRK,ZA,Prieska,Northern Cape,Pixley ka Seme District Municipality,AP
 PRM,LPPM,Portimao Airport,37.13333,-8.533333,0,,Europe/Lisbon,PRM,PT,Portimao,Faro,Portimao,AP
@@ -6406,7 +6406,7 @@ PXA,WIPY,Atung Bungsu Airport,-4.0225,103.379167,2020,,Asia/Jakarta,PXA,ID,Kotaa
 PXH,YPMH,Prominent Hill,-29.7101355,135.52772941953702,692,,Australia/Adelaide,PXH,AU,,,,AP
 PXL,P10,Polacca,35.8,-110.333336,5823,,America/Phoenix,PXL,US,First Mesa,Arizona,Navajo County,AP
 PXM,MMPS,Puerto Escondido Airport,15.85,-97.083336,0,,America/Mexico_City,PXM,MX,Puerto Escondido,Oaxaca,San Pedro Mixtepec -Dto. 22 -,AP
-PXN,VEPU,Purnea Airport,25.759599685668945,87.41000366210938,129,,Asia/Kolkata,PXN,IN,Purnia,Bihar,Purnia,AP
+PXN,VEPU,Purnea Airport,25.7596,87.41000366,129,,Asia/Kolkata,PXN,IN,Purnia,Bihar,,AP
 PXO,LPPS,Porto Santo Airport,33.07362365,-16.34816497905559,252,http://www.anam.pt/Porto-Santo-411.aspx,Atlantic/Madeira,PXO,PT,Vila de Porto Santo,Madeira,Porto Santo,AP
 PXR,VTUJ,Surin,14.86680565,103.4979606001036,331,,Asia/Bangkok,PXR,TH,Surin,Surin,,AP
 PXU,VVPK,Pleiku Airport,14.004424,108.0135475589313,2411,,Asia/Ho_Chi_Minh,PXU,VN,Pleiku,Gia Lai,,AP
@@ -6611,7 +6611,7 @@ RIV,KRIV,March ARB,33.8819433,-117.2590169,1536,,America/Los_Angeles,RIV,US,Rubi
 RIW,KRIW,Riverton Airport,43.064445,-108.45695,5442,,America/Denver,RIW,US,Riverton,Wyoming,Fremont County,AP
 RIX,EVRA,Riga International Airport,56.922239649999995,23.97264338931523,39,http://www.riga-airport.com/,Europe/Riga,RIX,LV,Pinki,Babite,,AP
 RIY,OYRN,Riyan Mukalla,14.660666299999999,49.37876752804668,49,,Asia/Aden,RIY,YE,Ghayl Ba Wazir,Muhafazat Hadramawt,Ghayl Ba Wazir,AP
-RIZ,ZSRZ,Rio Alzucar,8.25,-80.833336,232,http://www.rzairport.com.cn/,America/Panama,RIZ,PA,El Espino de Santa Rosa,Veraguas,,AP
+RIZ,ZSRZ,Rizhao Shanzihe Airport,35.399722,119.316667,114,http://www.rzairport.com.cn/,Asia/Shanghai,RIZ,CN,Rizhao,Shandong,,AP
 RJA,VORY,Rajahmundry Airport,17.105190399999998,81.81832195423078,114,http://aai.aero/allAirports/rajahmundry_generalinfo.jsp,Asia/Kolkata,RJA,IN,Rajahmundry,Andhra Pradesh,East Godavari,AP
 RJB,VNRB,Rajbiraj,26.483334,86.833336,209,,Asia/Kathmandu,RJB,NP,Rajbiraj,Eastern Region,,AP
 RJH,VGRJ,Rajshahi Airport,24.4382974,88.61425835907019,36,,Asia/Dhaka,RJH,BD,Rajshahi,Rajshahi,,AP
@@ -6983,7 +6983,7 @@ SHK,FXSH,Sehonghong,-29.475,27.833332,7132,,Africa/Maseru,SHK,LS,,,,AP
 SHL,VEBI,Shillong Airport,25.566668,91.88333,4960,,Asia/Kolkata,SHL,IN,Shillong,Meghalaya,East Khasi Hills,AP
 SHM,RJBD,Shirahama Airport,33.66245835,135.36280893177445,259,,Asia/Tokyo,SHM,JP,Tanabe,Wakayama,,AP
 SHN,KSHN,Sanderson Field,47.2334272,-123.147374,249,http://www.portofshelton.com/airport.html,America/Los_Angeles,SHN,US,Shelton,Washington,Mason County,AP
-SHO,RKND,King Mswati III International Airport,38.13333,128.6,164,http://www.eswacaa.co.sz/airports/kingmswatiIII/,Africa/Mbabane,MTS,SZ,,,,AP
+SHO,FDSK,King Mswati III International Airport,-26.356667,31.716944,1070,http://www.eswacaa.co.sz/airports/kingmswatiIII/,Africa/Mbabane,SHO,SZ,,,,AP
 SHQ,YSPT,Southport,-27.951944,153.42778,22,,Australia/Brisbane,SHQ,AU,Main Beach,Queensland,Gold Coast,AP
 SHR,KSHR,Sheridan,44.774166,-106.97722,3979,,America/Denver,SHR,US,Sheridan,Wyoming,Sheridan County,AP
 SHS,ZHSS,Shashi,30.316668,112.23333,144,,Asia/Shanghai,SHS,CN,Shashi,Hubei,,AP
@@ -7353,7 +7353,7 @@ SWF,KSWF,Stewart International Airport,41.5020532,-74.12120288016584,449,,Americ
 SWG,AYSW,Satwag,-6.1394439,147.27878072846525,4248,,Pacific/Port_Moresby,SWG,PG,,,,AP
 SWH,YSWH,Swan Hill,-35.38333,143.61667,200,,Australia/Melbourne,SWH,AU,Swan Hill,Victoria,Swan Hill,AP
 SWJ,NVSX,South West Bay,-16.25,167.16667,0,,Pacific/Efate,SWJ,VU,,,,AP
-SWL,RPSV,Spanish Wells,25.54,-76.75,45,,America/Nassau,SWL,BS,Spanish Wells,Spanish Wells,,AP
+SWL,RPSV,San Vicente Airport,10.525,119.273889,10,,Asia/Manila,SWL,PH,,,,AP
 SWM,,Suia-Missu,-11.216667,-53.25,895,,America/Cuiaba,SWM,BR,Sinop,Mato Grosso,Sinop,AP
 SWN,VISP,Sarsawa Airport,29.989555,77.408006,889,,Asia/Kolkata,SWN,IN,Sarsawa,Uttar Pradesh,Saharanpur,AP
 SWO,KSWO,Searcy Field,36.15889,-97.085556,954,http://stillwater.org/government/city_facilities/stillwater_regional_airport/,America/Chicago,SWO,US,Stillwater,Oklahoma,Payne County,AP
@@ -7819,7 +7819,7 @@ TRO,YTRE,Taree Airport,-31.8877679,152.51309188792249,38,,Australia/Sydney,TRO,A
 TRQ,SBTK,Tarauaca,-8.1,-70.75,646,,America/Rio_Branco,TRQ,BR,Tarauaca,Acre,Tarauaca,AP
 TRR,VCCT,China Bay,8.5387065,81.182420993587,6,,Asia/Colombo,TRR,LK,Trincomalee,Eastern Province,,AP
 TRS,LIPQ,Trieste - Friuli Venezia Giulia Airport,45.8261611,13.473368702886166,39,http://www.aeroporto.fvg.it/,Europe/Rome,TRS,IT,Ronchi dei Legionari,Friuli Venezia Giulia,Provincia di Gorizia,AP
-TRT,,Tremonton,41.716667,-112.166664,0,,America/Denver,TRT,US,Tremonton,Utah,Box Elder County,AP
+TRT,WAFB,Toraja Airport,-3.185833,119.91775,2883,,Asia/Makassar,TRT,ID,,,,AP
 TRU,SPRU,Trujillo Airport,-8.09,-79.115,106,,America/Lima,TRU,PE,Huanchaco,La Libertad,Provincia de Trujillo,AP
 TRV,VOTV,Trivandrum International Airport,8.4820416,76.91905902167463,15,,Asia/Kolkata,TRV,IN,Thiruvananthapuram,Kerala,Thiruvananthapuram,AP
 TRW,NGTA,Bonriki Airport,1.358333,172.94167,9,,Pacific/Tarawa,TRW,KI,Betio Village,Gilbert Islands,Tarawa,AP
@@ -8403,7 +8403,7 @@ WFK,KFVE,Frenchville,47.35,-68.333336,682,,America/New_York,WFK,US,Madawaska,Mai
 WGA,YSWG,Wagga Wagga Airport,-35.16567315,147.46300325635022,669,http://www.wagga.nsw.gov.au/www/html/271-airport.asp,Australia/Sydney,WGA,AU,Forest Hill,New South Wales,Wagga Wagga,AP
 WGC,VOWA,Warangal,17.9140552,79.6036086,958,http://aai.aero/allAirports/warrangal.jsp,Asia/Kolkata,WGC,IN,Warangal,Telangana,Warangal,AP
 WGE,YWLG,Walgett,-30.0321528,148.12542342678233,439,,Australia/Sydney,WGE,AU,Lightning Ridge,New South Wales,Walgett,AP
-WGN,ZGSY,Waitangi,-36.266945,174.1,131,,Pacific/Auckland,WGN,NZ,Dargaville,Northland,Kaipara District,AP
+WGN,ZGSY,Shaoyang Wugang Airport,26.802,110.642,1440,,Asia/Shanghai,WGN,CN,Shaoyang,Hunan,,AP
 WGO,KOKV,Winchester Regional,39.143367749999996,-78.14369087132627,718,http://websmart66.net/cgi-bin/p/w66p-home.cgi?d=winchester-aviation-services,America/New_York,WGO,US,Winchester,Virginia,City of Winchester,AP
 WGP,WATU,Waingapu Airport,-9.666667,120.3,55,,Asia/Makassar,WGP,ID,Mangga Dua,East Nusa Tenggara,,AP
 WGT,YWGT,Wangaratta,-36.36667,146.33333,465,,Australia/Melbourne,WGT,AU,Wangaratta,Victoria,Wangaratta,AP
@@ -8886,7 +8886,7 @@ YLS,CSH4,Lebel-Sur-Quevillon,49.02990215,-77.01652790419863,960,,America/Montrea
 YLT,CYLT,Alert,82.51855470000001,-62.272470382524084,100,,America/Pangnirtung,YLT,CA,Upernavik,Qaasuitsup,,AP
 YLV,UBEE,Yevlakh Airport,40.6264779,47.1460404,49,,Asia/Baku,YLV,AZ,Yevlakh,Yevlax City,,AP
 YLW,CYLW,Kelowna International Airport,49.956703700000006,-119.37954941396475,1421,http://www.kelowna.ca/CM/Page68.aspx,America/Vancouver,YLW,CA,Kelowna,British Columbia,,AP
-YLX,,Long Point,59.35,-94.68,0,,America/Toronto,YLX,CA,,,,AP
+YLX,ZGYL,Yulin Fumian Airport,22.438056,110.120833,449,,Asia/Shanghai,YLX,CN,Yulin,Guangxi Zhuang Autonomous Region,,AP
 YLY,CYNJ,Langley Regional,49.100854049999995,-122.62808976800964,34,,America/Vancouver,YLY,CA,Langley,British Columbia,,AP
 YMA,CYMA,Mayo,63.6166166,-135.8690225156807,1653,,America/Whitehorse,YMA,CA,,,,AP
 YMB,CAD5,Merritt,50.11667,-120.75,2080,,America/Vancouver,YMB,CA,Merritt,British Columbia,,AP
@@ -9017,7 +9017,7 @@ YSM,CYSM,Fort Smith Airport,60.0192725,-111.96200473689623,671,,America/Yellowkn
 YSN,CZAM,Salmon Arm,50.6828003,-119.228996,1751,http://www.salmonarm.ca/index.aspx?nid=228,America/Vancouver,YSN,CA,Salmon Arm,British Columbia,,AP
 YSO,CCD4,Postville Airport,54.916668,-59.966667,193,,America/Goose_Bay,YSO,CA,,,,AP
 YSP,CYSP,Marathon,48.75,-86.35,1035,,America/Toronto,YSP,CA,,,,AP
-YSQ,ZYSQ,Spring Island,59.45,-1.78,459,,America/Vancouver,YSQ,CA,Sandwick,Scotland,Shetland Islands,AP
+YSQ,ZYSQ,Songyuan Chaganhu Airport,44.938114,124.550178,460,,Asia/Shanghai,YSQ,CN,Songyuan,Jilin,,AP
 YST,CYST,Ste Therese Point,53.85,-94.65,773,,America/Winnipeg,YST,CA,,,,AP
 YSU,CYSU,Summerside,49.0,-57.983334,56,,America/Halifax,YSU,CA,Corner Brook,Newfoundland and Labrador,,AP
 YSX,CAW8,Shearwater,52.13333,-128.06667,0,,America/Vancouver,YSX,CA,,,,AP


### PR DESCRIPTION
Replaced several misassigned entries with correct airports, including:
AIP, CDE, CQW, HGI, HMS, HZA, JIO, KEA, LKI, RIZ, SWL, TRT, WGN, YLX, YSQ

Corrected existing records/coordinates and details for entries including:
PRH, PXN, SHO