### PR TITLE
fix: rename PBI to DJT for President Donald J. Trump International Airport

### DIFF
--- a/airports.csv
+++ b/airports.csv
@@ -1989,6 +1989,7 @@ DTN,KDTN,Shreveport Downtown,32.54041615,-93.74500728259136,187,http://www.shrev
 DTR,WN07,Decatur Island,48.5034859,-122.813495,39,,America/Los_Angeles,DTR,US,,,,AP
 DTU,ZYDU,Wudalianchi Dedu Airport,48.442918399999996,126.13780921753956,941,,Asia/Shanghai,DTU,CN,Baoquan,Heilongjiang Sheng,,AP
 DTW,KDTW,Detroit Metropolitan Wayne County Airport,42.205699100000004,-83.35297537621658,636,http://www.metroairport.com/,America/Detroit,DTT,US,Romulus,Michigan,Wayne County,AP
+DTX,KTKI,McKinney National Airport,33.177898,-96.5905,585,https://www.flytki.com/,America/Chicago,DFW,US,McKinney,Texas,Collin County,AP
 DUA,KDUA,Eaker,33.983334,-96.416664,682,,America/Chicago,DUA,US,Durant,Oklahoma,Bryan County,AP
 DUB,EIDW,Dublin Airport,53.4288026,-6.247592522077657,246,http://www.dublinairport.com/,Europe/Dublin,DUB,IE,Beaumont,Leinster,,AP
 DUC,KDUC,Halliburton Field,34.4720262,-97.960035,1099,,America/Chicago,DUC,US,Duncan,Oklahoma,Stephens County,AP

--- a/airports.csv
+++ b/airports.csv
@@ -1852,6 +1852,7 @@ DJJ,WAJJ,Sentani Airport,-2.5782397,140.5184882521964,269,https://sentani-airpor
 DJM,FCBD,Djambala,-2.515203,14.755771029863677,2493,,Africa/Brazzaville,DJM,CG,,,,AP
 DJN,D66,Delta Junction,64.0488787,-145.7171901,1122,,America/Anchorage,DJN,US,,,,AP
 DJO,DIDL,Daloa,6.866944,-6.466667,790,,Africa/Abidjan,DJO,CI,Daloa,Haut-Sassandra,,AP
+DJT,KDJT,President Donald J. Trump International Airport,26.6859478,-80.09248650717163,32,https://flydjt.org,America/New_York,PBI,US,Haverhill,Florida,Palm Beach County,AP
 DJU,BIDV,Djupivogur,64.6430303,-14.2775558,16,,Atlantic/Reykjavik,DJU,IS,Reydarfjoerdur,East,,AP
 DKA,,Katsina,13.0057213,7.659455216289262,1617,http://www.faannigeria.org/nigeria-airport.php?airport=18,Africa/Lagos,DKA,NG,Katsina,Katsina,,AP
 DKI,YDKI,Dunk Island,-17.9371869,146.140759,49,,Australia/Brisbane,DKI,AU,,,,AP
@@ -5984,7 +5985,6 @@ PBE,SKPR,Puerto Berrio,6.483333,-74.48333,524,,America/Bogota,PBE,CO,Puerto Berr
 PBF,KPBF,Grider Field,34.1744743,-91.9366952,127,http://www.pbaviation.com,America/Chicago,PBF,US,Pine Bluff,Arkansas,Jefferson County,AP
 PBG,KPBG,Plattsburgh International Airport,44.6689275,-73.4719379,206,http://www.plattsburghinternationalairport.com/,America/New_York,PBG,US,Plattsburgh West,New York,Clinton County,AP
 PBH,VQPR,Paro Airport,27.403184449999998,89.42341649453166,7293,,Asia/Thimphu,PBH,BT,Paro,Paro,,AP
-PBI,KPBI,Palm Beach International Airport,26.6859478,-80.09248650717163,32,http://www.pbia.org,America/New_York,PBI,US,Haverhill,Florida,Palm Beach County,AP
 PBJ,NVSI,Paama,-16.432021900000002,168.23523696852922,45,,Pacific/Efate,PBJ,VU,,,,AP
 PBL,SVPC,Puerto Cabello,10.4789026,-68.07287449307714,59,,America/Caracas,PBL,VE,Puerto Cabello,Carabobo,Municipio Puerto Cabello,AP
 PBM,SMJP,Zanderij International Airport,5.45209655,-55.18802501876111,52,http://www.japi-airport.com,America/Paramaribo,PBM,SR,Onverwacht,Para,,AP


### PR DESCRIPTION
Palm Beach International is now President Donald J. Trump International Airport. IATA `PBI` became `DJT` on 2026-08-18, ICAO `KPBI` became `KDJT` on 2026-07-09.

Four fields: `code`, `icao`, `name`, `url`. Renamed in place rather than added, since `PBI` is no longer allocated.

`city_code` deliberately stays `PBI`. Only the airport identifier changed, not the city code. `LNA` also points at `PBI`, so moving this one would leave two city codes for one city.

`url` is updated because `pbia.org` now 301s to `flydjt.org`.

Verified against [OurAirports](https://davidmegginson.github.io/ourairports-data/airports.csv): `icao_code` `KDJT`, `iata_code` `DJT`, name string matches exactly.

Sources: [FAA Notice 8900.780](https://www.faa.gov/regulations_policies/orders_notices/index.cfm/go/document.information/documentID/1045316), [flydjt.org FAQ](https://flydjt.org/about/name-change-faqs/), [Air Canada](https://www.aircanada.com/us/en/aco/home/book/travel-news-and-updates/2026/airport-code-change-for-west-palm-beach.html).