### PR TITLE
feat: add DTX for McKinney National Airport

### DIFF
--- a/airports.csv
+++ b/airports.csv
@@ -1988,6 +1988,7 @@ DTN,KDTN,Shreveport Downtown,32.54041615,-93.74500728259136,187,http://www.shrev
 DTR,WN07,Decatur Island,48.5034859,-122.813495,39,,America/Los_Angeles,DTR,US,,,,AP
 DTU,ZYDU,Wudalianchi Dedu Airport,48.442918399999996,126.13780921753956,941,,Asia/Shanghai,DTU,CN,Baoquan,Heilongjiang Sheng,,AP
 DTW,KDTW,Detroit Metropolitan Wayne County Airport,42.205699100000004,-83.35297537621658,636,http://www.metroairport.com/,America/Detroit,DTT,US,Romulus,Michigan,Wayne County,AP
+DTX,KTKI,McKinney National Airport,33.177898,-96.5905,585,https://www.flytki.com/,America/Chicago,DFW,US,McKinney,Texas,Collin County,AP
 DUA,KDUA,Eaker,33.983334,-96.416664,682,,America/Chicago,DUA,US,Durant,Oklahoma,Bryan County,AP
 DUB,EIDW,Dublin Airport,53.4288026,-6.247592522077657,246,http://www.dublinairport.com/,Europe/Dublin,DUB,IE,Beaumont,Leinster,,AP
 DUC,KDUC,Halliburton Field,34.4720262,-97.960035,1099,,America/Chicago,DUC,US,Duncan,Oklahoma,Stephens County,AP


### PR DESCRIPTION
McKinney National Airport (KTKI) is missing from `airports.csv`. It holds IATA code `DTX`.

```
DTX,KTKI,McKinney National Airport,33.177898,-96.5905,585,https://www.flytki.com/,America/Chicago,DFW,US,McKinney,Texas,Collin County,AP
```

Fields taken from the [OurAirports dataset](https://davidmegginson.github.io/ourairports-data/airports.csv) (`KTKI`, `iata_code` `DTX`, 33.177898 / -96.5905, 585 ft, Collin County, Texas) and the airport site <https://www.flytki.com/>.

`city_code` is `DFW`, matching how the other Dallas-Fort Worth metroplex fields in the dataset are filed (`ADS`, `AFW`, `RBD`, `DAL`).

Note that `TKI` in this dataset is Tokeen, Alaska (FAA `57A`), so there is no collision with the airport's FAA local code.

`scripts/validate_airports.py` passes with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)